### PR TITLE
feat: unnamed tuples

### DIFF
--- a/.changeset/four-terms-wave.md
+++ b/.changeset/four-terms-wave.md
@@ -1,0 +1,5 @@
+---
+'abitype': patch
+---
+
+Added support for tuples with unnamed parameters.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for your interest in contributing to AbiType! Please take a moment to review this document **before submitting a pull request.**
+Thanks for your interest in contributing to ABIType! Please take a moment to review this document **before submitting a pull request.**
 
 If you want to contribute, but aren't sure where to start, you can create a [new discussion](https://github.com/wagmi-dev/abitype/discussions).
 
@@ -55,7 +55,7 @@ gh repo clone wagmi-dev/abitype
 
 ## Installing Node.js and pnpm
 
-AbiType uses [pnpm](https://pnpm.io) as its package manager. You need to install **Node.js v16 or higher** and **pnpm v7 or higher**.
+ABIType uses [pnpm](https://pnpm.io) as its package manager. You need to install **Node.js v16 or higher** and **pnpm v7 or higher**.
 
 You can run the following commands in your terminal to check your local Node.js and npm versions:
 
@@ -89,10 +89,10 @@ After the install completes, [git hooks](https://github.com/toplenboren/simple-g
 
 ## Running tests
 
-Since AbiType is a type-only library, tests are run by checking types with the following:
+Since ABIType is a type-only library, tests are run by checking types with the TypeScript compiler:
 
 ```bash
-pnpm typecheck
+pnpm test
 ```
 
 <div align="right">
@@ -125,7 +125,7 @@ When you submit a pull request, GitHub will automatically lint, build, and test 
 ---
 
 <div align="center">
-  ✅ Now you're ready to contribute to AbiType! Follow the next steps if you need more advanced instructions.
+  ✅ Now you're ready to contribute to ABIType! Follow the next steps if you need more advanced instructions.
 </div>
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,7 +18,7 @@ body:
   - type: input
     attributes:
       label: Package Version
-      description: What version of AbiType are you using?
+      description: What version of abitype are you using?
       placeholder: 1.0.0
     validations:
       required: true
@@ -45,19 +45,19 @@ body:
     validations:
       required: false
 
+  - type: input
+    attributes:
+      label: Link to Minimal Reproducible Example ([TypeScript Playground](https://tsplay.dev/wjQvkW))
+      description: |
+        This makes investigating issues and helping you out significantly easier! For most issues, you will likely get asked to provide one so why not add one now :)
+      placeholder: https://tsplay.dev/wjQvkW
+    validations:
+      required: false
+
   - type: textarea
     attributes:
       label: Steps To Reproduce
       description: Steps or code snippets to reproduce the behavior.
-    validations:
-      required: false
-
-  - type: input
-    attributes:
-      label: Link to Minimal Reproducible Example ([TypeScript Playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgSQM4EEBGw4F84BmUEIcA5AIbYwCeYApmQFBO0NwBK9qArgDbwAvCgzYAPAG0AugD4gA), CodeSandbox, etc.)
-      description: |
-        This makes investigating issues and helping you out significantly easier! For most issues, you will likely get asked to provide one so why not add one now :)
-      placeholder: https://codesandbox.io
     validations:
       required: false
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# AbiType
+# ABIType
 
 [![npm](https://img.shields.io/npm/v/abitype.svg?colorA=21262d&colorB=161b22&style=flat)](https://www.npmjs.com/package/abitype)
 [![Downloads per month](https://img.shields.io/npm/dm/abitype?colorA=21262d&colorB=161b22&style=flat)](https://www.npmjs.com/package/abitype)
 
-Strict TypeScript types for Ethereum ABIs. AbiType provides utilities and type definitions for ABI properties and values, covering the [Contract ABI Specification](https://docs.soliditylang.org/en/latest/abi-spec.html).
+Strict TypeScript types for Ethereum ABIs. ABIType provides utilities and type definitions for ABI properties and values, covering the [Contract ABI Specification](https://docs.soliditylang.org/en/latest/abi-spec.html), as well as [EIP-712](https://eips.ethereum.org/EIPS/eip-712) Typed Data.
 
 ```ts
 import { ExtractAbiFunctions } from 'abitype'
@@ -13,7 +13,7 @@ const erc721Abi = [...] as const
 type Result = ExtractAbiFunctions<typeof erc721Abi, 'payable'>
 ```
 
-Works great for adding blazing fast [autocomplete](https://twitter.com/awkweb/status/1555678944770367493) and type checking to functions or variables. No need to generate types with third-party tools – just use your ABI and let TypeScript do the rest!
+Works great for adding blazing fast [autocomplete](https://twitter.com/awkweb/status/1555678944770367493) and type checking to functions, variables, or your own types. No need to generate types with third-party tools – just use your ABI and let TypeScript do the rest!
 
 ## Installation
 
@@ -23,7 +23,7 @@ npm install abitype
 
 ## Usage
 
-Since ABIs can contain deeply nested arrays, objects, and other types, you must assert your ABIs to constants using [`const` assertions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions). This allows TypeScript to take the most specific types for expressions and avoid type widening (e.g. no going from `"hello"` to `string`).
+Since ABIs can contain deeply nested arrays and objects, you must assert your ABIs to constants using [`const` assertions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions). This allows TypeScript to take the most specific types for expressions and avoid type widening (e.g. no going from `"hello"` to `string`).
 
 ```ts
 const erc721Abi = [...] as const
@@ -50,7 +50,7 @@ type Result = AbiParameterToPrimitiveType<{
 
 ### AbiParametersToPrimitiveTypes
 
-Converts array of `AbiParameter` to corresponding TypeScript primitive type.
+Converts array of `AbiParameter` to corresponding TypeScript primitive types.
 
 ```ts
 import { AbiParametersToPrimitiveTypes } from 'abitype'
@@ -80,7 +80,7 @@ type Result = AbiTypeToPrimitiveType<'address'>
 ```
 
 > **Note**
-> Does not include full array or tuple conversion. Use `AbiParameterToPrimitiveType` to fully convert arrays and tuples.
+> Does not include full array or tuple conversion. Use `AbiParameterToPrimitiveType` to fully convert array and tuple types.
 
 ### ExtractAbiError
 
@@ -186,6 +186,26 @@ Checks if type is `Abi`
 import { IsAbi } from 'abitype'
 
 type Result = IsAbi<typeof erc721Abi>
+```
+
+### IsTypedData
+
+Checks if type is `TypedData`
+
+```ts
+import { IsTypedData } from 'abitype'
+
+type Result = IsTypedData<{
+  Person: [
+    { name: 'name'; type: 'string' },
+    { name: 'wallet'; type: 'address' },
+  ]
+  Mail: [
+    { name: 'from'; type: 'Person' },
+    { name: 'to'; type: 'Person' },
+    { name: 'contents'; type: 'string' },
+  ]
+}>
 ```
 
 ### AbiEventSignature
@@ -321,6 +341,14 @@ import {
 } from 'abitype'
 ```
 
+### TypedDataParameter
+
+Entry in `TypedData` type items
+
+```ts
+import { TypedDataParameter } from 'abitype'
+```
+
 ### TypedDataType
 
 Subset of `AbiType` that excludes `tuple` and `function`
@@ -339,7 +367,7 @@ import { TypedData } from 'abitype'
 
 ## Configuration
 
-AbiType tries to strike a balance between type exhaustiveness and speed with sensible defaults. In some cases, you might want to tune your configuration (e.g. fixed array length). To do this, the following configuration options are available:
+ABIType tries to strike a balance between type exhaustiveness and speed with sensible defaults. In some cases, you might want to tune your configuration (e.g. fixed array length). To do this, the following configuration options are available:
 
 | Option                       | Type              | Default | Description                                                                                              |
 | ---------------------------- | ----------------- | ------- | -------------------------------------------------------------------------------------------------------- |
@@ -362,7 +390,7 @@ declare module 'abitype' {
 
 ## Support
 
-If you find AbiType useful, please consider supporting development. Thank you 🙏
+If you find ABIType useful, please consider supporting development. Thank you 🙏
 
 - [GitHub Sponsors](https://github.com/sponsors/wagmi-dev?metadata_campaign=gh_readme_support)
 - [Gitcoin Grant](https://gitcoin.co/grants/4493/wagmi-react-hooks-library-for-ethereum)

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,9 @@ export interface Config {
   [key: string]: unknown
 }
 
+/**
+ * Default {@link Config} options
+ */
 export interface DefaultConfig {
   /** Maximum depth for nested array types (e.g. string[][]) */
   ArrayMaxDepth: 2
@@ -21,6 +24,14 @@ export interface DefaultConfig {
   FixedArrayLengthUpperBound: 5
 }
 
+/**
+ * Resolve {@link Config} between user defined options and {@link DefaultConfig}
+ *
+ * @example
+ * import { ResolvedConfig } from 'abitype'
+ *
+ * ResolvedConfig['ArrayMaxDepth']
+ */
 export interface ResolvedConfig {
   ArrayMaxDepth: Config['ArrayMaxDepth'] extends number | false
     ? Config['ArrayMaxDepth']

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,10 +21,11 @@ export type {
   SolidityString,
   SolidityTuple,
   TypedData,
+  TypedDataParameter,
   TypedDataType,
 } from './abi'
 
-export type { Config, DefaultConfig } from './config'
+export type { Config, DefaultConfig, ResolvedConfig } from './config'
 
 export type {
   AbiEventSignature,
@@ -42,5 +43,6 @@ export type {
   ExtractAbiFunctionNames,
   ExtractAbiFunctions,
   IsAbi,
+  IsTypedData,
   TypedDataToPrimitiveTypes,
 } from './utils'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,16 @@
 /**
+ * Merges two types into new type
+ *
+ * @param Object1 - Object to merge into
+ * @param Object2 - Object to merge and override keys from {@link Object1}
+ *
+ * @example
+ * type Result = Merge<{ foo: string }, { foo: number; bar: string }>
+ * { foo: number; bar: string }
+ */
+export type Merge<Object1, Object2> = Omit<Object1, keyof Object2> & Object2
+
+/**
  * Creates range between two positive numbers using [tail recursion](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#tail-recursion-elimination-on-conditional-types).
  *
  * @param Start - Number to start range
@@ -50,15 +62,3 @@ type _TupleOf<
   TSize extends number,
   R extends unknown[],
 > = R['length'] extends TSize ? R : _TupleOf<TNumber, TSize, [TNumber, ...R]>
-
-/**
- * Merges two types into new type
- *
- * @param Object1 - Object to merge into
- * @param Object2 - Object to merge and override keys from {@link Object1}
- *
- * @example
- * type Result = Merge<{ foo: string }, { foo: number; bar: string }>
- * { foo: number; bar: string }
- */
-export type Merge<Object1, Object2> = Omit<Object1, keyof Object2> & Object2

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -25,6 +25,7 @@ import {
   ExtractAbiFunctionNames,
   ExtractAbiFunctions,
   IsAbi,
+  IsTypedData,
   TypedDataToPrimitiveTypes,
 } from './utils'
 
@@ -206,6 +207,38 @@ test('AbiParameterToPrimitiveType', () => {
       b: [2, 3],
       c: [{ x: 1, y: { a: 'foo' } }],
     })
+
+    type WithoutNamedParameterResult = AbiParameterToPrimitiveType<{
+      components: [
+        { name: ''; type: 'string' },
+        { name: 'symbol'; type: 'string' },
+        { name: 'description'; type: 'string' },
+        { name: 'imageURI'; type: 'string' },
+        { name: 'contentURI'; type: 'string' },
+        { name: 'price'; type: 'uint256' },
+        { name: 'limit'; type: 'uint256' },
+        { name: 'fundingRecipient'; type: 'address' },
+        { name: 'renderer'; type: 'address' },
+        { name: 'nonce'; type: 'uint256' },
+        { name: 'fee'; type: 'uint16' },
+      ]
+      internalType: 'struct IWritingEditions.WritingEdition'
+      name: 'edition'
+      type: 'tuple'
+    }>
+    expectType<WithoutNamedParameterResult>([
+      'Test',
+      '$TEST',
+      'Foo bar baz',
+      'ipfs://hash',
+      'arweave://digest',
+      0.1,
+      100,
+      address,
+      address,
+      123,
+      0,
+    ])
   })
 
   test('number', () => {
@@ -810,4 +843,29 @@ test('TypedDataToPrimitiveTypes', () => {
       },
     })
   })
+})
+
+test('IsTypedData', () => {
+  type Result = IsTypedData<{
+    Person: [
+      { name: 'name'; type: 'string' },
+      { name: 'wallet'; type: 'address' },
+    ]
+    Mail: [
+      { name: 'from'; type: 'Person' },
+      { name: 'to'; type: 'Person' },
+      { name: 'contents'; type: 'string' },
+    ]
+  }>
+  expectType<Result>(true)
+
+  type Result2 = IsTypedData<{
+    Person: [{ name: 'name'; type: 'string' }, { name: 'wallet'; type: 'merp' }]
+    Mail: [
+      { name: 'from'; type: 'Person' },
+      { name: 'to'; type: 'Person' },
+      { name: 'contents'; type: 'string' },
+    ]
+  }>
+  expectType<Result2>(false)
 })


### PR DESCRIPTION
## Description

Updates `AbiParameterToPrimitiveType` so tuples with unnamed parameters return arrays instead of objects.

For example, this tuple has all named parameters:

```ts
type Result = AbiParameterToPrimitiveType<{
  name: 'foo',
  type: 'tuple',
  components: [
    { name: 'abc', type: 'string' },
    { name: 'xyz', type: 'address' }
  ]
}>
```

So `Result` is:

```ts
type Result = {
  abc: string
  xyz: `0x${string}`
}
```

Add this tuple has an unnamed parameter:

```ts
type Result = AbiParameterToPrimitiveType<{
  name: 'foo',
  type: 'tuple',
  components: [
    { name: 'abc', type: 'string' },
    { name: '', type: 'address' }
  ]
}>
```

So `Result` is an array instead:

```ts
type Result = [string, `0x${string}`]
```

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth