### PR TITLE
feat: add config option for number type

### DIFF
--- a/.changeset/rich-falcons-study.md
+++ b/.changeset/rich-falcons-study.md
@@ -1,0 +1,5 @@
+---
+'abitype': patch
+---
+
+Added `NumberType` configuration option. `NumberType` sets the TypeScript type to use for `int` and `uint` values.

--- a/README.md
+++ b/README.md
@@ -369,11 +369,12 @@ import { TypedData } from 'abitype'
 
 ABIType tries to strike a balance between type exhaustiveness and speed with sensible defaults. In some cases, you might want to tune your configuration (e.g. fixed array length). To do this, the following configuration options are available:
 
-| Option                       | Type              | Default | Description                                                                                              |
-| ---------------------------- | ----------------- | ------- | -------------------------------------------------------------------------------------------------------- |
-| `ArrayMaxDepth`              | `number \| false` | `2`     | Maximum depth for nested array types (e.g. `string[][]`). When `false`, there is no maximum array depth. |
-| `FixedArrayLengthLowerBound` | `number`          | `1`     | Lower bound for fixed array length                                                                       |
-| `FixedArrayLengthUpperBound` | `number`          | `5`     | Upper bound for fixed array length                                                                       |
+| Option                       | Type              | Default            | Description                                                                                              |
+| ---------------------------- | ----------------- | ------------------ | -------------------------------------------------------------------------------------------------------- |
+| `ArrayMaxDepth`              | `number \| false` | `2`                | Maximum depth for nested array types (e.g. `string[][]`). When `false`, there is no maximum array depth. |
+| `FixedArrayLengthLowerBound` | `number`          | `1`                | Lower bound for fixed array length                                                                       |
+| `FixedArrayLengthUpperBound` | `number`          | `5`                | Upper bound for fixed array length                                                                       |
+| `NumberType`                 | TypeScript type   | `number \| bigint` | TypeScript type to use for `int` and `uint` values.                                                      |
 
 Configuration options are customizable using [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html). Just extend the `Config` interface either directly in your code or in a `d.ts` file (e.g. `abi.d.ts`):
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,8 @@ export interface DefaultConfig {
   FixedArrayLengthLowerBound: 1
   /** Upper bound for fixed array length */
   FixedArrayLengthUpperBound: 5
+  /** TypeScript type to use for `int` and `uint` values */
+  NumberType: number | bigint
 }
 
 /**
@@ -42,4 +44,7 @@ export interface ResolvedConfig {
   FixedArrayLengthUpperBound: Config['FixedArrayLengthUpperBound'] extends number
     ? Config['FixedArrayLengthUpperBound']
     : DefaultConfig['FixedArrayLengthUpperBound']
+  NumberType: Config['NumberType'] extends number | bigint
+    ? Config['NumberType']
+    : DefaultConfig['NumberType']
 }

--- a/src/examples.ts
+++ b/src/examples.ts
@@ -217,12 +217,12 @@ export function readContracts<T extends unknown[]>(
 
 export function signTypedData<
   TTypedData extends TypedData,
-  Schema extends TypedDataToPrimitiveTypes<TTypedData>,
+  TSchema extends TypedDataToPrimitiveTypes<TTypedData>,
 >(_config: {
   /** Named list of all type definitions */
   types: TTypedData
   /** Data to sign */
-  value: Schema[keyof Schema]
+  value: TSchema[keyof TSchema]
 }) {
   return {} as Address
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,7 @@ import {
   TypedDataParameter,
   TypedDataType,
 } from './abi'
+import { ResolvedConfig } from './config'
 import { Merge, Tuple } from './types'
 
 /**
@@ -44,7 +45,7 @@ type PrimitiveTypeLookup = {
 } & {
   [_ in SolidityFunction]: `${Address}${string}`
 } & {
-  [_ in SolidityInt]: number | bigint
+  [_ in SolidityInt]: ResolvedConfig['NumberType']
 } & {
   [_ in SolidityString]: string
 } & {

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,13 +1,19 @@
 /**
  * Assert parameter is of a specific type.
  *
- * @param _value - Value that should be identical to type `T`.
+ * @param value - Value that should be identical to type `T`.
  */
-export function expectType<T>(_value: T): void {
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function expectType<T>(value: T): void {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
 }
 
-export function test(_name: string, _callback: () => void) {
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function test(name: string, _callback: () => void) {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
 }
 


### PR DESCRIPTION
## Description

Adds `NumberType` configuration option for configuring the TypeScript type to use for `int` and `uint` values. Useful if a library outputs something other than `number | bigint` when return numbers. For example, the current version of ethers uses its own `BigNumber` implementation:

```ts
import { BigNumber } from 'ethers'

declare module 'abitype' {
  export interface Config {
    NumberType: BigNumber
  }
}
```

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
