### PR TITLE
feat(tsc):  interop

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,11 @@
 name: Main
 
 on:
+  workflow_dispatch: {}
   pull_request:
   push:
     branches: [main]
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,24 +1,54 @@
 {
-  "compilerOptions": {
-    "allowJs": false,
-    "downlevelIteration": true,
-    "esModuleInterop": true,
-    "isolatedModules": true,
-    "lib": ["es2019", "es2017", "dom"],
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "noEmit": true,
-    "noImplicitAny": true,
-    "noUncheckedIndexedAccess": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "target": "es2021",
-    "types": ["node"]
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "formatCodeOptions": {
+    "tabSize": 2,
+    "indentSize": 2
   },
-  "exclude": ["node_modules", "dist"],
-  "include": ["src"]
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": false,
+    "allowUnreachableCode": false,
+    "esModuleInterop": false,
+    "tsBuildInfoFile": "./",
+    "forceConsistentCasingInFileNames": true,
+    "strictPropertyInitialization": true,
+    "noFallthroughCasesInSwitch": true,
+    "useUnknownInCatchVariables": true,
+    "noUncheckedIndexedAccess": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "preserveValueImports": true,
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "strictNullChecks": true,
+    "isolatedModules": true,
+    "removeComments": true,
+    "incremental": true,
+    "declaration": true,
+    "sourceMap": false,
+    "moduleResolution": "nodenext",
+    "moduleDetection": "auto",
+    "module": "NodeNext",
+    "target": "ESNext",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "types": [
+      "@types/node"
+    ],
+    "plugins": [
+      {
+        "name": "typescript-eslint-language-service"
+      }
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "**/node_modules",
+    "**/.*/",
+    "src/**/*.test.ts",
+    "dist/**"
+  ]
 }


### PR DESCRIPTION
## Description

This changes the TSConfig to disable esmodeinterop (this makes it an OPT-IN for downstream users instead of a requirement). We can disable it as this is a zero-dep library

## Additional Information

Additionally I enabled type import enforcement, I can fix these issues or disable the option, depends on what you prefer:
```console
Error: src/abi.ts(1,10): error TS1444: 'ResolvedConfig' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/abi.ts(2,10): error TS1444: 'Range' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/config.ts(1,10): error TS1444: 'IsUnknown' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/examples.ts(1,10): error TS1444: 'Abi' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/examples.ts(1,15): error TS1444: 'AbiEvent' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/examples.ts(1,25): error TS1444: 'AbiFunction' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/examples.ts(1,38): error TS1444: 'Address' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/examples.ts(1,47): error TS1444: 'TypedData' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/examples.ts(3,3): error TS1444: 'AbiParametersToPrimitiveTypes' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/examples.ts(4,3): error TS1444: 'ExtractAbiEvent' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/examples.ts(5,3): error TS1444: 'ExtractAbiEventNames' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/examples.ts(6,3): error TS1444: 'ExtractAbiFunction' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/examples.ts(7,3): error TS1444: 'ExtractAbiFunctionNames' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/examples.ts(8,3): error TS1444: 'TypedDataToPrimitiveTypes' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts(2,3): error TS1444: 'Abi' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts(3,3): error TS1444: 'AbiParameter' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts(4,3): error TS1444: 'AbiStateMutability' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts(5,3): error TS1444: 'AbiType' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts(6,3): error TS1444: 'MBits' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts(7,3): error TS1444: 'SolidityAddress' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts(8,3): error TS1444: 'SolidityArray' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts(9,3): error TS1444: 'SolidityBool' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts(10,3): error TS1444: 'SolidityBytes' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts(11,3): error TS1444: 'SolidityFixedArrayRange' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts(12,3): error TS1444: 'SolidityFixedArraySizeLookup' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts(13,3): error TS1444: 'SolidityFunction' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts(14,3): error TS1444: 'SolidityInt' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts(15,3): error TS1444: 'SolidityString' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts([16](https://github.com/sambacha/abitype/actions/runs/3064236046/jobs/4947156015#step:6:17),3): error TS1444: 'SolidityTuple' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts([17](https://github.com/sambacha/abitype/actions/runs/3064236046/jobs/4947156015#step:6:18),3): error TS1444: 'TypedData' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts([18](https://github.com/sambacha/abitype/actions/runs/3064236046/jobs/4947156015#step:6:19),3): error TS1444: 'TypedDataParameter' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts([19](https://github.com/sambacha/abitype/actions/runs/3064236046/jobs/4947156015#step:6:20),3): error TS1444: 'TypedDataType' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts(21,10): error TS1444: 'ResolvedConfig' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts(22,10): error TS1444: 'Merge' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
Error: src/utils.ts([22](https://github.com/sambacha/abitype/actions/runs/3064236046/jobs/4947156015#step:6:23),17): error TS1[44](https://github.com/sambacha/abitype/actions/runs/3064236046/jobs/4947156015#step:6:45)4: 'Tuple' is a type and must be imported using a type-only import when 'preserveValueImports' and 'isolatedModules' are both enabled.
```
- [x] I read the [contributing docs](/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
