### PR TITLE
Fix broken examples link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ const erc721Abi = [...] as const
 type Result = ExtractAbiFunctions<typeof erc721Abi, 'payable'>
 ```
 
-Works great for adding blazing fast [autocomplete](https://twitter.com/awkweb/status/1555678944770367493) and type checking to functions, variables, or your own types ([see examples](/src/examples.ts)). No need to generate types with third-party tools – just use your ABI and let TypeScript do the rest!
+Works great for adding blazing fast [autocomplete](https://twitter.com/awkweb/status/1555678944770367493) and type checking to functions, variables, or your own types ([see examples](/src/examples/examples.ts)). No need to generate types with third-party tools – just use your ABI and let TypeScript do the rest!
 
 ## Installation
 


### PR DESCRIPTION

## Description

README/DOCS: Currently, clicking examples takes the user to a 404 page.
## Additional Information

- [ ] I read the [contributing docs](/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
