### PR TITLE
feat: add NullUnindexedFlag to AbiParameterToPrimitiveType for event filter args

### DIFF
--- a/.changeset/thin-wombats-sip.md
+++ b/.changeset/thin-wombats-sip.md
@@ -1,0 +1,5 @@
+---
+'abitype': patch
+---
+
+Added NullUnindexedFlag to AbiParameterToPrimitiveType for event filter args.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ type Result = AbiParameterToPrimitiveType<{
 }>
 ```
 
+> **Note**
+> With optional `NullUnindexedFlag` returns null for `AbiParameter` with exactly `{ indexed: false }`
+>
+> (For use with event filter arguments)
+
 ### AbiParametersToPrimitiveTypes
 
 Converts array of `AbiParameter` to corresponding TypeScript primitive types.
@@ -68,6 +73,11 @@ type Result = AbiParametersToPrimitiveTypes<
   ]
 >
 ```
+
+> **Note**
+> With optional `NullUnindexedFlag` returns null for `AbiParameter` with exactly `{ indexed: false }`
+>
+> (For use with event filter arguments)
 
 ### AbiTypeToPrimitiveType
 

--- a/src/examples/examples.test.ts
+++ b/src/examples/examples.test.ts
@@ -432,7 +432,7 @@ test('writeContract', () => {
 })
 
 test('watchContractEvent', () => {
-  test('args', () => {
+  test('listener args', () => {
     test('zero', () => {
       const abi = [
         {
@@ -473,6 +473,45 @@ test('watchContractEvent', () => {
           expectType<Address>(from)
           expectType<Address>(to)
           expectType<ResolvedConfig['BigIntType']>(tokenId)
+        },
+      })
+    })
+  })
+
+  test('filter args', () => {
+    test('are optional', () => {
+      watchContractEvent({
+        address,
+        abi: writingEditionsFactoryAbi,
+        eventName: 'FactoryLimitSet',
+        args: [],
+        listener() {
+          return
+        },
+      })
+    })
+
+    test('uninedex allow only null', () => {
+      watchContractEvent({
+        address,
+        abi: writingEditionsFactoryAbi,
+        eventName: 'FactoryGuardSet',
+        // @ts-expect-error no args allowed
+        args: [false],
+        listener() {
+          return
+        },
+      })
+    })
+
+    test('indexed allow their type or null', () => {
+      watchContractEvent({
+        address,
+        abi: writingEditionsFactoryAbi,
+        eventName: 'RoyaltyChange',
+        args: [address, undefined, null, null],
+        listener() {
+          return
         },
       })
     })


### PR DESCRIPTION
## Description

I want to add filter arguments to useContractEvent, and a queryFilter/useQueryFilter.
Unindexed topics should only allow null/undefined, so I added a flag for that

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)