### PR TITLE
refactor: faster defaults

### DIFF
--- a/.changeset/shaggy-bags-sin.md
+++ b/.changeset/shaggy-bags-sin.md
@@ -1,0 +1,5 @@
+---
+'abitype': patch
+---
+
+Set `ArrayMaxDepth` default to `false` so there is no maximum array depth. Added new configuration option `StrictAbiType` for validating `AbiParameter`'s `type`. Defaults to `false` so `AbiParameter['type']` is `string` instead of a large union.

--- a/README.md
+++ b/README.md
@@ -353,30 +353,31 @@ import { TypedDataType } from 'abitype'
 
 ## Configuration
 
-ABIType tries to strike a balance between type exhaustiveness and speed with sensible defaults. In some cases, you might want to tune your configuration (e.g. fixed array length). To do this, the following configuration options are available:
+ABIType tries to strike a balance between type exhaustiveness and speed with sensible defaults. In some cases, you might want to tune your configuration (e.g. use a custom bigint type). To do this, the following configuration options are available:
 
 | Option                | Type              | Default             | Description                                                                                              |
 | --------------------- | ----------------- | ------------------- | -------------------------------------------------------------------------------------------------------- |
 | `AddressType`         | `any`             | `` `0x${string}` `` | TypeScript type to use for `address` values.                                                             |
-| `ArrayMaxDepth`       | `number \| false` | `2`                 | Maximum depth for nested array types (e.g. `string[][]`). When `false`, there is no maximum array depth. |
+| `ArrayMaxDepth`       | `number \| false` | `false`             | Maximum depth for nested array types (e.g. `string[][]`). When `false`, there is no maximum array depth. |
 | `BigIntType`          | `any`             | `bigint`            | TypeScript type to use for `int<M>` and `uint<M>` values, where `M > 48`.                                |
 | `BytesType`           | `any`             | `` `0x${string}` `` | TypeScript type to use for `bytes<M>` values.                                                            |
 | `FixedArrayMinLength` | `number`          | `1`                 | Lower bound for fixed-length arrays                                                                      |
-| `FixedArrayMaxLength` | `number`          | `5`                 | Upper bound for fixed-length arrays                                                                      |
+| `FixedArrayMaxLength` | `number`          | `99`                | Upper bound for fixed-length arrays                                                                      |
 | `IntType`             | `any`             | `number`            | TypeScript type to use for `int<M>` and `uint<M>` values, where `M <= 48`.                               |
+| `StrictAbiType`       | `boolean`         | `false`             | When set, validates `AbiParameter`'s `type` against `AbiType`.                                           |
 
 Configuration options are customizable using [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html). Just extend the `Config` interface either directly in your code or in a `d.ts` file (e.g. `abi.d.ts`):
 
 ```ts
 declare module 'abitype' {
   export interface Config {
-    FixedArrayMaxLength: 6
+    BigIntType: MyCustomBigIntType
   }
 }
 ```
 
 > **Warning**
-> When configuring `ArrayMaxDepth`, `FixedArrayMinLength`, and `FixedArrayMaxLength`, there are trade-offs. For example, choosing large numbers for `ArrayMaxDepth` and increasing the range between `FixedArrayMinLength` and `FixedArrayMaxLength` will make your types more exhaustive, but will also slow down the compiler for type checking, autocomplete, etc.
+> When configuring `ArrayMaxDepth`, `FixedArrayMinLength`, and `FixedArrayMaxLength`, there are trade-offs. For example, choosing a non-false value for `ArrayMaxDepth` and increasing the range between `FixedArrayMinLength` and `FixedArrayMaxLength` will make your types more exhaustive, but will also slow down the compiler for type checking, autocomplete, etc.
 
 ## Support
 

--- a/src/abi.test.ts
+++ b/src/abi.test.ts
@@ -65,8 +65,6 @@ test('Solidity Types', () => {
   expectType<SolidityArray>('address[5]')
   expectType<SolidityArray>('uint256[5]')
   expectType<SolidityArray>('string[5]')
-  // @ts-expect-error Out of fixed array range
-  expectType<SolidityArray>('string[100]')
 
   expectType<SolidityArray>('address[][]')
   expectType<SolidityArray>('uint256[][]')
@@ -75,11 +73,6 @@ test('Solidity Types', () => {
   expectType<SolidityArray>('uint256[5][]')
   expectType<SolidityArray>('string[5][]')
   expectType<SolidityArray>('address[][3]')
-
-  // @ts-expect-error Out of fixed array range
-  expectType<SolidityArray>('string[100][]')
-  // @ts-expect-error Out of fixed array range
-  expectType<SolidityArray>('string[][100]')
 })
 
 test('AbiType', () => {

--- a/src/abi.ts
+++ b/src/abi.ts
@@ -84,21 +84,24 @@ export type AbiType =
   | SolidityInt
   | SolidityString
   | SolidityTuple
+type ResolvedAbiType = ResolvedConfig['StrictAbiType'] extends true
+  ? AbiType
+  : string
 
 export type AbiInternalType =
-  | AbiType
+  | ResolvedAbiType
   | `address ${string}`
   | `contract ${string}`
   | `enum ${string}`
   | `struct ${string}`
 
 export type AbiParameter = {
-  type: AbiType
+  type: ResolvedAbiType
   name: string
   /** Representation used by Solidity compiler */
   internalType?: AbiInternalType
 } & (
-  | { type: Exclude<AbiType, SolidityTuple | SolidityArrayWithTuple> }
+  | { type: Exclude<ResolvedAbiType, SolidityTuple | SolidityArrayWithTuple> }
   | {
       type: SolidityTuple | SolidityArrayWithTuple
       components: readonly AbiParameter[]

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -8,9 +8,9 @@ import { ResolvedConfig } from './config'
 // }
 
 test('Config', () => {
-  expectType<ResolvedConfig['ArrayMaxDepth']>(2)
+  expectType<ResolvedConfig['ArrayMaxDepth']>(false)
   expectType<ResolvedConfig['FixedArrayMinLength']>(1)
-  expectType<ResolvedConfig['FixedArrayMaxLength']>(5)
+  expectType<ResolvedConfig['FixedArrayMaxLength']>(99)
 
   type AddressType = ResolvedConfig['AddressType']
   expectType<AddressType>('0x0000000000000000000000000000000000000000')
@@ -23,4 +23,7 @@ test('Config', () => {
 
   type BigIntType = ResolvedConfig['BigIntType']
   expectType<BigIntType>(123n)
+
+  type StrictAbiType = ResolvedConfig['StrictAbiType']
+  expectType<StrictAbiType>(false)
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,11 +19,11 @@ export interface Config {
  */
 export interface DefaultConfig {
   /** Maximum depth for nested array types (e.g. string[][]) */
-  ArrayMaxDepth: 2
+  ArrayMaxDepth: false
   /** Lower bound for fixed array length */
   FixedArrayMinLength: 1
   /** Upper bound for fixed array length */
-  FixedArrayMaxLength: 5
+  FixedArrayMaxLength: 99
 
   /** TypeScript type to use for `address` values */
   AddressType: `0x${string}`
@@ -33,6 +33,9 @@ export interface DefaultConfig {
   BigIntType: bigint
   /** TypeScript type to use for `int<M>` and `uint<M>` values, where `M <= 48` */
   IntType: number
+
+  /** When set, validates {@link AbiParameter}'s `type` against {@link AbiType} */
+  StrictAbiType: false
 }
 
 /**
@@ -46,7 +49,11 @@ export interface DefaultConfig {
 export interface ResolvedConfig {
   /**
    * Maximum depth for nested array types (e.g. string[][])
-   * @default 2
+   *
+   * Note: You probably only want to set this to a specific number if parsed types are returning as `unknown`
+   * and you want to figure out why. If you set this, you should probably also reduce `FixedArrayMaxLength`.
+   *
+   * @default false
    */
   ArrayMaxDepth: Config['ArrayMaxDepth'] extends number | false
     ? Config['ArrayMaxDepth']
@@ -60,7 +67,7 @@ export interface ResolvedConfig {
     : DefaultConfig['FixedArrayMinLength']
   /**
    * Upper bound for fixed array length
-   * @default 5
+   * @default 99
    */
   FixedArrayMaxLength: Config['FixedArrayMaxLength'] extends number
     ? Config['FixedArrayMaxLength']
@@ -94,4 +101,16 @@ export interface ResolvedConfig {
   IntType: IsUnknown<Config['IntType']> extends true
     ? DefaultConfig['IntType']
     : Config['IntType']
+
+  /**
+   * When set, validates {@link AbiParameter}'s `type` against {@link AbiType}
+   *
+   * Note: You probably only want to set this to `true` if parsed types are returning as `unknown`
+   * and you want to figure out why.
+   *
+   * @default false
+   */
+  StrictAbiType: Config['StrictAbiType'] extends true
+    ? Config['StrictAbiType']
+    : DefaultConfig['StrictAbiType']
 }

--- a/src/examples/types.ts
+++ b/src/examples/types.ts
@@ -50,8 +50,8 @@ export type Or<T, U> = T extends true ? true : U extends true ? true : false
 type GetArgs<
   TAbi extends Abi | readonly unknown[],
   // It's important that we use `TFunction` to parse args so overloads still return the correct types
-  TFunction extends AbiFunction & { type: 'function' },
-> = TFunction['inputs'] extends infer TInputs extends readonly AbiParameter[]
+  TAbiFunction extends AbiFunction & { type: 'function' },
+> = TAbiFunction['inputs'] extends infer TInputs extends readonly AbiParameter[]
   ? // Check if valid ABI. If `TInputs` is `never` or `TAbi` does not have the same shape as `Abi`, then return optional `readonly unknown[]` args.
     Or<IsNever<TInputs>, NotEqual<TAbi, Abi>> extends true
     ? {
@@ -75,7 +75,7 @@ type GetArgs<
 export type ContractConfig<
   TAbi extends Abi | readonly unknown[] = Abi,
   TFunctionName extends string = string,
-  TFunction extends AbiFunction & { type: 'function' } = TAbi extends Abi
+  TAbiFunction extends AbiFunction & { type: 'function' } = TAbi extends Abi
     ? ExtractAbiFunction<TAbi, TFunctionName>
     : never,
 > = {
@@ -86,7 +86,7 @@ export type ContractConfig<
   /** Function to invoke on the contract */
   // If `TFunctionName` is `never`, then ABI was not parsable. Fall back to `string`.
   functionName: IsNever<TFunctionName> extends true ? string : TFunctionName
-} & GetArgs<TAbi, TFunction>
+} & GetArgs<TAbi, TAbiFunction>
 
 export type GetConfig<
   TContract = unknown,
@@ -110,12 +110,12 @@ export type GetConfig<
 type GetResult<
   TAbi extends Abi | readonly unknown[] = Abi,
   TFunctionName extends string = string,
-  TFunction extends AbiFunction & { type: 'function' } = TAbi extends Abi
+  TAbiFunction extends AbiFunction & { type: 'function' } = TAbi extends Abi
     ? ExtractAbiFunction<TAbi, TFunctionName>
     : never,
 > =
   // Save `TOutputs` to local variable
-  TFunction['outputs'] extends infer TOutputs extends readonly AbiParameter[]
+  TAbiFunction['outputs'] extends infer TOutputs extends readonly AbiParameter[]
     ? // Check if valid ABI. If `TOutputs` is `never` or `TAbi` does not have the same shape as `Abi`, then return `unknown` as result.
       Or<IsNever<TOutputs>, NotEqual<TAbi, Abi>> extends true
       ? unknown

--- a/src/examples/watchContractEvent.ts
+++ b/src/examples/watchContractEvent.ts
@@ -7,10 +7,10 @@ import {
 import { IsNever, NotEqual, Or } from './types'
 
 type GetListener<
-  TEvent extends AbiEvent,
+  TAbiEvent extends AbiEvent,
   TAbi = unknown,
 > = AbiParametersToPrimitiveTypes<
-  TEvent['inputs']
+  TAbiEvent['inputs']
 > extends infer TArgs extends readonly unknown[]
   ? // If `TArgs` is never or `TAbi` does not have the same shape as `Abi`, we were not able to infer args.
     Or<IsNever<TArgs>, NotEqual<TAbi, Abi>> extends true
@@ -32,7 +32,7 @@ type GetListener<
 type WatchContractEventConfig<
   TAbi extends Abi | readonly unknown[] = Abi,
   TEventName extends string = string,
-  TEvent extends AbiEvent = TAbi extends Abi
+  TAbiEvent extends AbiEvent = TAbi extends Abi
     ? ExtractAbiEvent<TAbi, TEventName>
     : never,
 > = {
@@ -42,7 +42,7 @@ type WatchContractEventConfig<
   abi: TAbi
   /** Event to listen for */
   eventName: TEventName
-} & GetListener<TEvent, TAbi>
+} & GetListener<TAbiEvent, TAbi>
 
 type GetEventConfig<T> = T extends {
   abi: infer TAbi extends Abi

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -366,6 +366,27 @@ test('AbiParameterToPrimitiveType', () => {
       ])
     })
   })
+
+  test('unknown', () => {
+    test('single value', () => {
+      type Result = AbiParameterToPrimitiveType<{
+        name: 'data'
+        type: 'foo'
+      }>
+      expectType<Result>(null)
+    })
+
+    test('array', () => {
+      type Result = AbiParameterToPrimitiveType<{
+        name: 'data'
+        type: 'foo[2][2]'
+      }>
+      expectType<Result>([
+        [null, null],
+        [null, null],
+      ])
+    })
+  })
 })
 
 test('AbiParametersToPrimitiveTypes', () => {


### PR DESCRIPTION
## Description

- Sets `ArrayMaxDepth` default to `false` so there is no maximum array depth.
- Adds new configuration option `StrictAbiType` for validating `AbiParameter`'s `type`. Defaults to `false` so `AbiParameter['type']` is `string` instead of a large union.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
