### PR TITLE
feat: Narrow

### DIFF
--- a/.changeset/selfish-scissors-smell.md
+++ b/.changeset/selfish-scissors-smell.md
@@ -1,0 +1,5 @@
+---
+'abitype': patch
+---
+
+Added `Narrow` type

--- a/README.md
+++ b/README.md
@@ -23,14 +23,16 @@ npm install abitype
 
 ## Usage
 
-Since ABIs can contain deeply nested arrays and objects, you must assert your ABIs to constants using [`const` assertions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions). This allows TypeScript to take the most specific types for expressions and avoid type widening (e.g. no going from `"hello"` to `string`).
+Since ABIs can contain deeply nested arrays and objects, you must either assert ABIs to constants using [`const` assertions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) or use the built-in `narrow` function (works with JavaScript). This allows TypeScript to take the most specific types for expressions and avoid type widening (e.g. no going from `"hello"` to `string`).
 
 ```ts
 const erc721Abi = [...] as const
+const erc721Abi = <const>[...]
 ```
 
 ```ts
-const erc721Abi = <const>[...]
+import { narrow } from 'abitype'
+const erc721Abi = narrow([...])
 ```
 
 ## Utilities

--- a/src/examples/readContract.test.ts
+++ b/src/examples/readContract.test.ts
@@ -172,7 +172,6 @@ test('readContract', () => {
           },
         ],
         functionName: 'foo',
-        args: [],
       })
       const result2 = readContract({
         address,

--- a/src/examples/readContract.ts
+++ b/src/examples/readContract.ts
@@ -1,14 +1,12 @@
 import { Abi } from '../abi'
 import { GetConfig, GetReturnType } from './types'
 
-export function readContract<
+export declare function readContract<
   TAbi extends Abi | readonly unknown[],
   TFunctionName extends string,
 >(
-  _config: GetConfig<
+  config: GetConfig<
     { abi: TAbi; functionName: TFunctionName },
     'pure' | 'view'
   >,
-): GetReturnType<{ abi: TAbi; functionName: TFunctionName }> {
-  return {} as any
-}
+): GetReturnType<{ abi: TAbi; functionName: TFunctionName }>

--- a/src/examples/readContracts.test.ts
+++ b/src/examples/readContracts.test.ts
@@ -167,7 +167,7 @@ test('readContracts', () => {
       })
       type Result = typeof result
       //   ^?
-      type Expected = [string, `0x${string}`, unknown] extends Result
+      type Expected = Result extends [string, `0x${string}`, unknown]
         ? true
         : false
       expectType<Expected>(true)

--- a/src/examples/readContracts.ts
+++ b/src/examples/readContracts.ts
@@ -51,12 +51,10 @@ type ContractsResult<
     GetReturnType<{ abi: TAbi; functionName: TFunctionName }>[]
   : GetReturnType[]
 
-export function readContracts<
+export declare function readContracts<
   TAbi extends Abi | readonly unknown[],
   TFunctionName extends string,
   TContracts extends { abi: TAbi; functionName: TFunctionName }[],
->(_config: {
+>(config: {
   contracts: readonly [...ContractsConfig<TContracts>]
-}): ContractsResult<TContracts> {
-  return {} as any
-}
+}): ContractsResult<TContracts>

--- a/src/examples/signTypedData.ts
+++ b/src/examples/signTypedData.ts
@@ -1,33 +1,33 @@
 import { Address, TypedData, TypedDataDomain } from '../abi'
+import { Narrow } from '../narrow'
 import { TypedDataToPrimitiveTypes } from '../utils'
 
-type GetValue<TSchema = unknown> = TSchema[keyof TSchema] extends infer TValue
-  ? // Check if we were able to infer the shape of typed data
-    { [key: string]: any } extends TValue
-    ? {
-        /**
-         * Data to sign
-         *
-         * Use a [const assertion](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) on {@link types} for type inference.
-         */
-        value: Record<string, unknown>
-      }
-    : {
-        /** Data to sign */
-        value: TValue
-      }
-  : never
-
-type SignTypedDataConfig<TTypedData = TypedData, TSchema = unknown> = {
+type SignTypedDataConfig<TTypedData = unknown> = {
   /** Domain info */
   domain: TypedDataDomain
   /** Named list of all type definitions */
-  types: TTypedData
-} & GetValue<TSchema>
+  types: Narrow<TTypedData>
+} & (TTypedData extends TypedData
+  ? TypedDataToPrimitiveTypes<TTypedData> extends infer TSchema
+    ? TSchema[keyof TSchema] extends infer TValue
+      ? // Check if we were able to infer the shape of typed data
+        { [key: string]: any } extends TValue
+        ? {
+            /**
+             * Data to sign
+             *
+             * Use a [const assertion](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) on {@link types} for type inference.
+             */
+            value: { [key: string]: unknown }
+          }
+        : {
+            /** Data to sign */
+            value: TValue
+          }
+      : never
+    : never
+  : never)
 
-export function signTypedData<
-  TTypedData extends TypedData,
-  TSchema extends TypedDataToPrimitiveTypes<TTypedData>,
->(_config: SignTypedDataConfig<TTypedData, TSchema>) {
-  return {} as Address
-}
+export declare function signTypedData<
+  TTypedData extends TypedData | { [key: string]: unknown },
+>(config: SignTypedDataConfig<TTypedData>): Address

--- a/src/examples/watchContractEvent.test.ts
+++ b/src/examples/watchContractEvent.test.ts
@@ -11,21 +11,25 @@ import { watchContractEvent } from './watchContractEvent'
 test('watchContractEvent', () => {
   test('args', () => {
     test('zero', () => {
-      const abi = [
-        {
-          name: 'Foo',
-          type: 'event',
-          inputs: [],
-          anonymous: false,
-        },
-      ] as const
       watchContractEvent({
         address,
-        abi,
+        abi: [
+          {
+            name: 'Foo',
+            type: 'event',
+            inputs: [],
+            anonymous: false,
+          },
+          {
+            name: 'Bar',
+            type: 'event',
+            inputs: [{ name: 'baz', type: 'uint256', indexed: false }],
+            anonymous: false,
+          },
+        ],
         eventName: 'Foo',
-        // @ts-expect-error no args allowed
-        listener(_arg) {
-          return
+        listener(...args) {
+          expectType<[]>(args)
         },
       })
     })
@@ -57,25 +61,26 @@ test('watchContractEvent', () => {
 
   test('behavior', () => {
     test('works without const assertion', () => {
+      const abi = [
+        {
+          name: 'Foo',
+          type: 'event',
+          inputs: [
+            {
+              indexed: true,
+              name: 'name',
+              type: 'address',
+            },
+          ],
+          anonymous: false,
+        },
+      ]
       watchContractEvent({
         address,
-        abi: [
-          {
-            name: 'Foo',
-            type: 'event',
-            inputs: [
-              {
-                indexed: true,
-                name: 'name',
-                type: 'string',
-              },
-            ],
-            anonymous: false,
-          },
-        ],
+        abi,
         eventName: 'Foo',
         listener(name) {
-          expectType<typeof name>(name as unknown)
+          expectType<unknown>(name)
         },
       })
     })

--- a/src/examples/watchContractEvent.ts
+++ b/src/examples/watchContractEvent.ts
@@ -1,29 +1,43 @@
-import { Abi, AbiEvent, AbiParameter, Address } from '../abi'
+import { Abi, AbiEvent, Address } from '../abi'
+import { Narrow } from '../narrow'
+import { ExtractAbiEvent, ExtractAbiEventNames } from '../utils'
 import {
-  AbiParameterToPrimitiveType,
-  ExtractAbiEvent,
-  ExtractAbiEventNames,
-} from '../utils'
-import { IsNever, NotEqual, Or } from './types'
+  AbiEventParametersToPrimitiveTypes,
+  IsNever,
+  NotEqual,
+  Or,
+} from './types'
 
-type AbiEventParametersToPrimitiveTypes<
-  TAbiParameters extends readonly (AbiParameter & {
-    indexed?: boolean
-  })[],
-> = {
-  // TODO: Convert to labeled tuple so parameter names show up in autocomplete
-  // e.g. [foo: string, bar: string]
-  // https://github.com/microsoft/TypeScript/issues/44939
-  [K in keyof TAbiParameters]:
-    | AbiParameterToPrimitiveType<TAbiParameters[K]>
-    // If event is not indexed, add `null` to type
-    | (TAbiParameters[K]['indexed'] extends true ? never : null)
+type GetEventConfig<TContract> = TContract extends {
+  abi: infer TAbi extends Abi
+  eventName: infer TEventName extends string
 }
+  ? WatchContractEventConfig<
+      TAbi,
+      ExtractAbiEventNames<TAbi>,
+      ExtractAbiEvent<TAbi, TEventName>
+    >
+  : TContract extends {
+      abi: infer TAbi extends readonly unknown[]
+      eventName: infer TEventName extends string
+    }
+  ? WatchContractEventConfig<TAbi, TEventName>
+  : WatchContractEventConfig
 
-type GetListener<
-  TAbiEvent extends AbiEvent,
+type WatchContractEventConfig<
   TAbi = unknown,
-> = AbiEventParametersToPrimitiveTypes<
+  TEventName extends string = string,
+  TAbiEvent extends AbiEvent = TAbi extends Abi
+    ? ExtractAbiEvent<TAbi, TEventName>
+    : never,
+> = {
+  /** Contract address */
+  address: Address
+  /** Contract ABI */
+  abi: Narrow<TAbi>
+  /** Event to listen for */
+  eventName: IsNever<TEventName> extends true ? string : TEventName
+} & (AbiEventParametersToPrimitiveTypes<
   TAbiEvent['inputs']
 > extends infer TArgs extends readonly unknown[]
   ? // If `TArgs` is never or `TAbi` does not have the same shape as `Abi`, we were not able to infer args.
@@ -41,38 +55,7 @@ type GetListener<
         /** Callback when event is emitted */
         listener: (...args: TArgs) => void
       }
-  : never
-
-type WatchContractEventConfig<
-  TAbi extends Abi | readonly unknown[] = Abi,
-  TEventName extends string = string,
-  TAbiEvent extends AbiEvent = TAbi extends Abi
-    ? ExtractAbiEvent<TAbi, TEventName>
-    : never,
-> = {
-  /** Contract address */
-  address: Address
-  /** Contract ABI */
-  abi: TAbi
-  /** Event to listen for */
-  eventName: TEventName
-} & GetListener<TAbiEvent, TAbi>
-
-type GetEventConfig<T> = T extends {
-  abi: infer TAbi extends Abi
-  eventName: infer TEventName extends string
-}
-  ? WatchContractEventConfig<
-      TAbi,
-      ExtractAbiEventNames<TAbi>,
-      ExtractAbiEvent<TAbi, TEventName>
-    >
-  : T extends {
-      abi: infer TAbi extends readonly unknown[]
-      eventName: infer TEventName extends string
-    }
-  ? WatchContractEventConfig<TAbi, TEventName>
-  : WatchContractEventConfig
+  : never)
 
 export function watchContractEvent<
   TAbi extends Abi | readonly unknown[],

--- a/src/examples/writeContract.test.ts
+++ b/src/examples/writeContract.test.ts
@@ -220,13 +220,13 @@ test('writeContract', () => {
             type: 'function',
             stateMutability: 'payable',
             inputs: [{ type: 'string', name: '' }],
-            outputs: [{ type: 'string', name: '' }],
+            outputs: [{ type: 'address', name: '' }],
           },
         ],
         functionName: 'foo',
         args: ['bar'],
       })
-      expectType<typeof result>(result as unknown)
+      expectType<ResolvedConfig['AddressType']>(result)
     })
   })
 })

--- a/src/examples/writeContract.ts
+++ b/src/examples/writeContract.ts
@@ -1,14 +1,12 @@
 import { Abi } from '../abi'
 import { GetConfig, GetReturnType } from './types'
 
-export function writeContract<
+export declare function writeContract<
   TAbi extends Abi | readonly unknown[],
   TFunctionName extends string,
 >(
-  _config: GetConfig<
+  config: GetConfig<
     { abi: TAbi; functionName: TFunctionName },
     'nonpayable' | 'payable'
   >,
-): GetReturnType<{ abi: TAbi; functionName: TFunctionName }> {
-  return {} as any
-}
+): GetReturnType<{ abi: TAbi; functionName: TFunctionName }>

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,9 @@ export type {
 
 export type { Config, DefaultConfig, ResolvedConfig } from './config'
 
+export type { Narrow } from './narrow'
+export { narrow } from './narrow'
+
 export type {
   AbiParameterToPrimitiveType,
   AbiParametersToPrimitiveTypes,

--- a/src/narrow.test.ts
+++ b/src/narrow.test.ts
@@ -1,0 +1,18 @@
+import { expectType, test } from '../test'
+import { Narrow, narrow } from './narrow'
+
+test('Narrow', () => {
+  expectType<Narrow<['foo', 'bar', 1]>>(['foo', 'bar', 1])
+})
+
+test('narrow', () => {
+  const asConst = narrow(['foo', 'bar', 1])
+  //    ^?
+  type Result = typeof asConst
+  expectType<Result>(['foo', 'bar', 1])
+
+  expectType<'foo'>(narrow('foo'))
+  expectType<1>(narrow(1))
+  expectType<true>(narrow(true))
+  expectType<{ foo: 'bar' }>(narrow({ foo: 'bar' }))
+})

--- a/src/narrow.ts
+++ b/src/narrow.ts
@@ -1,0 +1,32 @@
+/**
+ * Infers embedded primitive type of any type
+ *
+ * @param T - Type to infer
+ * @returns Embedded type of {@link TType}
+ *
+ * @example
+ * type Result = Narrow<['foo', 'bar', 1]>
+ */
+// s/o https://twitter.com/hd_nvim/status/1578567206190780417
+export type Narrow<TType> =
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  | (TType extends Function ? TType : never)
+  | (TType extends string | number | boolean | bigint ? TType : never)
+  | (TType extends [] ? [] : never)
+  | {
+      [K in keyof TType]: Narrow<TType[K]>
+    }
+
+/**
+ * Infers embedded primitive type of any type
+ * Same as `as const` but without setting the object as readonly and without needing the user to use it.
+ *
+ * @param value - Value to infer
+ * @returns Value with embedded type inferred
+ *
+ * @example
+ * const result = narrow(['foo', 'bar', 1])
+ */
+export function narrow<TType>(value: Narrow<TType>) {
+  return value
+}


### PR DESCRIPTION
## Description

Adds `Narrow` type for type inference support in plain JS

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
