### PR TITLE
feat: make `AbiParameter['name']` optional

### DIFF
--- a/.changeset/poor-ducks-repeat.md
+++ b/.changeset/poor-ducks-repeat.md
@@ -1,0 +1,5 @@
+---
+'abitype': patch
+---
+
+Made `AbiParameter['name']` optional

--- a/src/abi.ts
+++ b/src/abi.ts
@@ -97,7 +97,7 @@ export type AbiInternalType =
 
 export type AbiParameter = {
   type: ResolvedAbiType
-  name: string
+  name?: string
   /** Representation used by Solidity compiler */
   internalType?: AbiInternalType
 } & (

--- a/src/examples/types.ts
+++ b/src/examples/types.ts
@@ -171,9 +171,11 @@ type GetResult<
            * | `[{ name: 'foo', type: 'uint256' }, { name: '', type: 'string' }]`    | `readonly [bigint, string] & { foo: bigint }`              |
            */
           {
-            [Output in TOutputs[number] as Output['name'] extends ''
-              ? never
-              : Output['name']]: AbiParameterToPrimitiveType<Output>
+            [Output in TOutputs[number] as Output extends { name: string }
+              ? Output['name'] extends ''
+                ? never
+                : Output['name']
+              : never]: AbiParameterToPrimitiveType<Output>
           } & AbiParametersToPrimitiveTypes<TOutputs>
         : unknown
       : never

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,7 +95,11 @@ export type AbiParameterToPrimitiveType<
         ]
       : // All tuple parameters are named so return as object
         {
-          [Component in TComponents[number] as Component['name']]: AbiParameterToPrimitiveType<Component>
+          [Component in TComponents[number] as Component extends {
+            name: string
+          }
+            ? Component['name']
+            : never]: AbiParameterToPrimitiveType<Component>
         }
     : // 3. Check if type is array.
     /**
@@ -144,9 +148,11 @@ type _HasUnnamedAbiParameter<TAbiParameters extends readonly AbiParameter[]> =
     infer Head extends AbiParameter,
     ...infer Tail extends readonly AbiParameter[],
   ]
-    ? Head['name'] extends ''
-      ? true
-      : _HasUnnamedAbiParameter<Tail>
+    ? Head extends { name: string }
+      ? Head['name'] extends ''
+        ? true
+        : _HasUnnamedAbiParameter<Tail>
+      : false
     : false
 
 /**


### PR DESCRIPTION
## Description

Make `AbiParameter['name']` optional

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
