### PR TITLE
feat: calculate stateMutability for deprecated constant and payable fields

### DIFF
--- a/.changeset/yellow-pets-suffer.md
+++ b/.changeset/yellow-pets-suffer.md
@@ -1,0 +1,5 @@
+---
+'abitype': patch
+---
+
+Added `stateMutability` calculation for older contracts that only use deprecated `constant` and `payable` fields.

--- a/src/zod/zod.test.ts
+++ b/src/zod/zod.test.ts
@@ -62,4 +62,82 @@ describe('AbiSchema', () => {
       ]"
     `)
   })
+
+  describe('behavior', () => {
+    it("deprecated 'constant' field", () => {
+      expect(
+        Abi.parse([
+          {
+            constant: true,
+            inputs: [{ name: 'node', type: 'bytes32' }],
+            name: 'resolver',
+            outputs: [{ name: '', type: 'address' }],
+            payable: false,
+            type: 'function',
+          },
+        ]),
+      ).toMatchInlineSnapshot(`
+        [
+          {
+            "constant": true,
+            "inputs": [
+              {
+                "name": "node",
+                "type": "bytes32",
+              },
+            ],
+            "name": "resolver",
+            "outputs": [
+              {
+                "name": "",
+                "type": "address",
+              },
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function",
+          },
+        ]
+      `)
+    })
+
+    it("deprecated 'payable' field", () => {
+      expect(
+        Abi.parse([
+          {
+            constant: false,
+            inputs: [
+              { name: 'node', type: 'bytes32' },
+              { name: 'owner', type: 'address' },
+            ],
+            name: 'setOwner',
+            outputs: [],
+            payable: false,
+            type: 'function',
+          },
+        ]),
+      ).toMatchInlineSnapshot(`
+        [
+          {
+            "constant": false,
+            "inputs": [
+              {
+                "name": "node",
+                "type": "bytes32",
+              },
+              {
+                "name": "owner",
+                "type": "address",
+              },
+            ],
+            "name": "setOwner",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function",
+          },
+        ]
+      `)
+    })
+  })
 })

--- a/test/abis.ts
+++ b/test/abis.ts
@@ -1600,3 +1600,116 @@ export const nounsAuctionHouseAbi = [
     type: 'function',
   },
 ] as const
+
+/**
+ * ENS
+ * https://etherscan.io/address/0x314159265dd8dbb310642f98f50c066173c1259b
+ */
+export const ensAbi = [
+  {
+    constant: true,
+    inputs: [{ name: 'node', type: 'bytes32' }],
+    name: 'resolver',
+    outputs: [{ name: '', type: 'address' }],
+    payable: false,
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [{ name: 'node', type: 'bytes32' }],
+    name: 'owner',
+    outputs: [{ name: '', type: 'address' }],
+    payable: false,
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      { name: 'node', type: 'bytes32' },
+      { name: 'label', type: 'bytes32' },
+      { name: 'owner', type: 'address' },
+    ],
+    name: 'setSubnodeOwner',
+    outputs: [],
+    payable: false,
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      { name: 'node', type: 'bytes32' },
+      { name: 'ttl', type: 'uint64' },
+    ],
+    name: 'setTTL',
+    outputs: [],
+    payable: false,
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [{ name: 'node', type: 'bytes32' }],
+    name: 'ttl',
+    outputs: [{ name: '', type: 'uint64' }],
+    payable: false,
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      { name: 'node', type: 'bytes32' },
+      { name: 'resolver', type: 'address' },
+    ],
+    name: 'setResolver',
+    outputs: [],
+    payable: false,
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      { name: 'node', type: 'bytes32' },
+      { name: 'owner', type: 'address' },
+    ],
+    name: 'setOwner',
+    outputs: [],
+    payable: false,
+    type: 'function',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, name: 'node', type: 'bytes32' },
+      { indexed: false, name: 'owner', type: 'address' },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, name: 'node', type: 'bytes32' },
+      { indexed: true, name: 'label', type: 'bytes32' },
+      { indexed: false, name: 'owner', type: 'address' },
+    ],
+    name: 'NewOwner',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, name: 'node', type: 'bytes32' },
+      { indexed: false, name: 'resolver', type: 'address' },
+    ],
+    name: 'NewResolver',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, name: 'node', type: 'bytes32' },
+      { indexed: false, name: 'ttl', type: 'uint64' },
+    ],
+    name: 'NewTTL',
+    type: 'event',
+  },
+] as const


### PR DESCRIPTION
## Description

Calculate `stateMutability` for older contracts that only use deprecated `constant` and `payable` fields (like [ENS](https://etherscan.io/address/0x314159265dd8dbb310642f98f50c066173c1259b)).

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
