### PR TITLE
tmm/remove 712 aliases

### DIFF
--- a/.changeset/mighty-keys-grab.md
+++ b/.changeset/mighty-keys-grab.md
@@ -1,0 +1,5 @@
+---
+'abitype': patch
+---
+
+Removed `uint` and `int` from `TypedDataType` (not allowed in spec).

--- a/src/abi.ts
+++ b/src/abi.ts
@@ -173,7 +173,7 @@ export type TypedDataDomain = {
   version?: string
 }
 
-// Subset of `AbiType` that excludes `tuple` and `function`
+// Subset of `AbiType` that excludes `tuple`, `function`, and dynamic aliases `int` and `uint`
 export type TypedDataType = Exclude<
   AbiType,
   SolidityFunction | SolidityTuple | SolidityArrayWithTuple | 'int' | 'uint'

--- a/src/abi.ts
+++ b/src/abi.ts
@@ -176,7 +176,7 @@ export type TypedDataDomain = {
 // Subset of `AbiType` that excludes `tuple` and `function`
 export type TypedDataType = Exclude<
   AbiType,
-  SolidityFunction | SolidityTuple | SolidityArrayWithTuple
+  SolidityFunction | SolidityTuple | SolidityArrayWithTuple | 'int' | 'uint'
 >
 
 export type TypedDataParameter = {


### PR DESCRIPTION
## Description

Removed aliases `uint` and `int` from `TypedDataType`

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
