### PR TITLE
fix: cast `uint` & `int` to `bigint`

### DIFF
--- a/.changeset/fresh-files-kneel.md
+++ b/.changeset/fresh-files-kneel.md
@@ -1,0 +1,5 @@
+---
+'abitype': minor
+---
+
+**Breaking:** `uint` and `int` types now cast to `ResolvedConfig['BigIntType']` instead of `ResolvedConfig['IntType'] | ResolvedConfig['BigIntType']`.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,13 +65,13 @@ type PrimitiveTypeLookup<
 
 type GreaterThan48Bits = Exclude<MBits, 8 | 16 | 24 | 32 | 40 | 48 | ''>
 type LessThanOrEqualTo48Bits = Exclude<MBits, GreaterThan48Bits | ''>
-type DynamicBits = Exclude<MBits, GreaterThan48Bits | LessThanOrEqualTo48Bits>
+type NoBits = Exclude<MBits, GreaterThan48Bits | LessThanOrEqualTo48Bits>
 type BitsTypeLookup = {
   [_ in `${LessThanOrEqualTo48Bits}`]: ResolvedConfig['IntType']
 } & {
   [_ in `${GreaterThan48Bits}`]: ResolvedConfig['BigIntType']
 } & {
-  [_ in DynamicBits]: ResolvedConfig['IntType'] | ResolvedConfig['BigIntType']
+  [_ in NoBits]: ResolvedConfig['BigIntType']
 }
 
 /**


### PR DESCRIPTION
## Description

`uint` and `int` are aliased to `uint256` and `int256` by default.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
