### PR TITLE
fix: properly type tuple components that are all unnamed

### DIFF
--- a/.changeset/stupid-snakes-tickle.md
+++ b/.changeset/stupid-snakes-tickle.md
@@ -1,0 +1,5 @@
+---
+'abitype': patch
+---
+
+Fixed type for excluded `name` in `AbiParameter`.

--- a/.changeset/stupid-snakes-tickle.md
+++ b/.changeset/stupid-snakes-tickle.md
@@ -2,4 +2,4 @@
 'abitype': patch
 ---
 
-Fixed type for excluded `name` in `AbiParameter`.
+Fixed derived type of `AbiParameterToPrimitiveType` for tuples that have all unnamed components.

--- a/src/utils.test-d.ts
+++ b/src/utils.test-d.ts
@@ -220,7 +220,7 @@ test('AbiParameterToPrimitiveType', () => {
       c: [{ x: 1n, y: { a: 'foo' } }],
     })
 
-    type WithoutNamedParameterResult = AbiParameterToPrimitiveType<{
+    type WithoutNamedComponentResult = AbiParameterToPrimitiveType<{
       components: [
         { name: ''; type: 'string' },
         { type: 'string' },
@@ -239,7 +239,7 @@ test('AbiParameterToPrimitiveType', () => {
       name: 'edition'
       type: 'tuple'
     }>
-    assertType<WithoutNamedParameterResult>([
+    assertType<WithoutNamedComponentResult>([
       'Test',
       'Test',
       '$TEST',
@@ -254,17 +254,25 @@ test('AbiParameterToPrimitiveType', () => {
       0,
     ])
 
-    type WithoutNamedParametersResult = AbiParameterToPrimitiveType<{
+    type WithoutNamedComponentsResult = AbiParameterToPrimitiveType<{
       components: [{ type: 'string' }, { type: 'uint' }, { type: 'address' }]
       internalType: 'struct IWritingEditions.WritingEdition'
       name: 'edition'
       type: 'tuple'
     }>
-    assertType<WithoutNamedParametersResult>([
+    assertType<WithoutNamedComponentsResult>([
       'Test',
       5n,
       '0x0000000000000000000000000000000000000000',
     ])
+
+    type WithoutComponentsResult = AbiParameterToPrimitiveType<{
+      components: []
+      internalType: 'struct IWritingEditions.WritingEdition'
+      name: 'edition'
+      type: 'tuple'
+    }>
+    assertType<WithoutComponentsResult>([])
   })
 
   test('number', () => {

--- a/src/utils.test-d.ts
+++ b/src/utils.test-d.ts
@@ -253,6 +253,18 @@ test('AbiParameterToPrimitiveType', () => {
       123n,
       0,
     ])
+
+    type WithoutNamedParametersResult = AbiParameterToPrimitiveType<{
+      components: [{ type: 'string' }, { type: 'uint' }, { type: 'address' }]
+      internalType: 'struct IWritingEditions.WritingEdition'
+      name: 'edition'
+      type: 'tuple'
+    }>
+    assertType<WithoutNamedParametersResult>([
+      'Test',
+      5n,
+      '0x0000000000000000000000000000000000000000',
+    ])
   })
 
   test('number', () => {

--- a/src/utils.test-d.ts
+++ b/src/utils.test-d.ts
@@ -109,7 +109,7 @@ test('AbiParameterToPrimitiveType', () => {
   })
 
   test('bool', () => {
-    type Result = AbiParameterToPrimitiveType<{ name: ''; type: 'bool' }>
+    type Result = AbiParameterToPrimitiveType<{ type: 'bool' }>
     assertType<Result>(true)
     assertType<Result>(false)
   })
@@ -124,7 +124,6 @@ test('AbiParameterToPrimitiveType', () => {
 
   test('function', () => {
     type FunctionResult = AbiParameterToPrimitiveType<{
-      name: ''
       type: 'function'
     }>
     assertType<FunctionResult>(`${address}foo`)
@@ -132,7 +131,6 @@ test('AbiParameterToPrimitiveType', () => {
 
   test('string', () => {
     type Result = AbiParameterToPrimitiveType<{
-      name: ''
       type: 'string'
     }>
     assertType<Result>('foo')
@@ -225,6 +223,7 @@ test('AbiParameterToPrimitiveType', () => {
     type WithoutNamedParameterResult = AbiParameterToPrimitiveType<{
       components: [
         { name: ''; type: 'string' },
+        { type: 'string' },
         { name: 'symbol'; type: 'string' },
         { name: 'description'; type: 'string' },
         { name: 'imageURI'; type: 'string' },
@@ -241,6 +240,7 @@ test('AbiParameterToPrimitiveType', () => {
       type: 'tuple'
     }>
     assertType<WithoutNamedParameterResult>([
+      'Test',
       'Test',
       '$TEST',
       'Foo bar baz',
@@ -270,7 +270,6 @@ test('AbiParameterToPrimitiveType', () => {
   test('array', () => {
     test('dynamic', () => {
       type Result = AbiParameterToPrimitiveType<{
-        name: ''
         type: 'string[]'
       }>
       assertType<Result>(['foo', 'bar', 'baz'])
@@ -278,7 +277,6 @@ test('AbiParameterToPrimitiveType', () => {
 
     test('fixed', () => {
       type Result = AbiParameterToPrimitiveType<{
-        name: ''
         type: 'string[3]'
       }>
       assertType<Result>(['foo', 'bar', 'baz'])
@@ -329,7 +327,6 @@ test('AbiParameterToPrimitiveType', () => {
   test('2d array', () => {
     test('dynamic', () => {
       type Result = AbiParameterToPrimitiveType<{
-        name: ''
         type: 'string[][]'
       }>
       assertType<Result>([['foo'], ['bar'], ['baz']])
@@ -338,14 +335,12 @@ test('AbiParameterToPrimitiveType', () => {
     test('fixed', () => {
       assertType<
         AbiParameterToPrimitiveType<{
-          name: ''
           type: 'string[][3]'
         }>
       >([['foo'], ['bar'], ['baz']])
 
       assertType<
         AbiParameterToPrimitiveType<{
-          name: ''
           type: 'string[3][]'
         }>
       >([
@@ -355,7 +350,6 @@ test('AbiParameterToPrimitiveType', () => {
 
       assertType<
         AbiParameterToPrimitiveType<{
-          name: ''
           type: 'string[3][3]'
         }>
       >([
@@ -366,7 +360,6 @@ test('AbiParameterToPrimitiveType', () => {
 
       assertType<
         AbiParameterToPrimitiveType<{
-          name: ''
           type: 'string[3][3]'
         }>
         // @ts-expect-error not enough items

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,7 +93,9 @@ export type AbiParameterToPrimitiveType<
         type: SolidityTuple
         components: infer TComponents extends readonly AbiParameter[]
       }
-    ? _HasUnnamedAbiParameter<TComponents> extends true
+    ? TComponents extends readonly []
+      ? []
+      : _HasUnnamedAbiParameter<TComponents> extends true
       ? // Has unnamed tuple parameters so return as array
         readonly [
           ...{

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -167,7 +167,7 @@ type _HasUnnamedAbiParameter<TAbiParameters extends readonly AbiParameter[]> =
       ? Head['name'] extends ''
         ? true
         : _HasUnnamedAbiParameter<Tail>
-      : false
+      : true
     : false
 
 /**


### PR DESCRIPTION
## Description

This PR fixes two issues where:
- if all tuple `components` are unnamed, it would be typed as `{}`. 
- if tuple `components` is an empty array, is would be typed as `{}`

Also refactored some tests to remove the `name` attribute completely for cleanliness.

### Before

Unnamed components:

<img width="729" alt="Screenshot 2023-02-22 at 10 47 38 am" src="https://user-images.githubusercontent.com/7336481/220484582-2969f72d-aa49-4d4d-9529-157fbb2e3783.png">

Empty components:

<img width="602" alt="Screenshot 2023-02-22 at 10 47 43 am" src="https://user-images.githubusercontent.com/7336481/220484593-6991b510-f0bd-4883-82cd-eb2e2981986c.png">

### After

Unnamed components:

<img width="887" alt="Screenshot 2023-02-22 at 10 47 14 am" src="https://user-images.githubusercontent.com/7336481/220484620-d66abc0a-6a80-486a-92a1-625fec4d36a6.png">

Empty components:

<img width="626" alt="Screenshot 2023-02-22 at 10 47 21 am" src="https://user-images.githubusercontent.com/7336481/220484626-ea48fa9f-f069-4067-90ea-3c66974c5606.png">

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
