### PR TITLE
refactor: human-readable parameter types

### DIFF
--- a/.changeset/dirty-buses-join.md
+++ b/.changeset/dirty-buses-join.md
@@ -1,0 +1,5 @@
+---
+'abitype': patch
+---
+
+Updated internal parse types.

--- a/docs/api/human.md
+++ b/docs/api/human.md
@@ -334,10 +334,10 @@ const abi = parseAbi([
 
 Parses human-readable ABI item (e.g. error, event, function) into ABI item.
 
-| Name         | Description              | Type                  |
-| ------------ | ------------------------ | --------------------- |
-| `signatures` | Human-Readable ABI item. | `string \| string[]`  |
-| returns      | Parsed ABI item          | `TAbiItem` (inferred) |
+| Name        | Description              | Type                  |
+| ----------- | ------------------------ | --------------------- |
+| `signature` | Human-Readable ABI item. | `string \| string[]`  |
+| returns     | Parsed ABI item          | `TAbiItem` (inferred) |
 
 #### Example
 

--- a/src/human-readable/parseAbi.test-d.ts
+++ b/src/human-readable/parseAbi.test-d.ts
@@ -1,17 +1,22 @@
-import { assertType, expectTypeOf, test } from 'vitest'
+import { expectTypeOf, test } from 'vitest'
+
+import type { Abi } from '../abi'
 
 import type { seaportHumanReadableAbi } from '../test'
 import type { IsAbi } from '../utils'
 import type { ParseAbi } from './parseAbi'
+import { parseAbi } from './parseAbi'
 
 test('ParseAbi', () => {
   type SeaportAbi = ParseAbi<typeof seaportHumanReadableAbi>
-  assertType<IsAbi<SeaportAbi>>(true)
+  expectTypeOf<IsAbi<SeaportAbi>>().toEqualTypeOf<true>()
 
-  assertType<ParseAbi<[]>>([])
-  assertType<ParseAbi<['struct Foo { string name; }']>>([])
+  expectTypeOf<ParseAbi<[]>>().toEqualTypeOf<never>()
+  expectTypeOf<
+    ParseAbi<['struct Foo { string name; }']>
+  >().toEqualTypeOf<never>()
 
-  assertType<
+  expectTypeOf<
     ParseAbi<
       [
         'function foo()',
@@ -19,81 +24,131 @@ test('ParseAbi', () => {
         'struct Foo { string name; }',
       ]
     >
-  >([
-    {
-      name: 'foo',
-      type: 'function',
-      stateMutability: 'nonpayable',
-      inputs: [],
-      outputs: [],
-    },
-    {
-      name: 'bar',
-      type: 'function',
-      stateMutability: 'nonpayable',
-      inputs: [
-        {
-          type: 'tuple',
-          components: [
-            {
-              name: 'name',
-              type: 'string',
-            },
-          ],
-        },
-        {
-          type: 'bytes32',
-        },
-      ],
-      outputs: [],
-    },
-  ])
+  >().toEqualTypeOf<
+    readonly [
+      {
+        readonly name: 'foo'
+        readonly type: 'function'
+        readonly stateMutability: 'nonpayable'
+        readonly inputs: readonly []
+        readonly outputs: readonly []
+      },
+      {
+        readonly name: 'bar'
+        readonly type: 'function'
+        readonly stateMutability: 'nonpayable'
+        readonly inputs: readonly [
+          {
+            readonly type: 'tuple'
+            readonly components: readonly [
+              {
+                readonly name: 'name'
+                readonly type: 'string'
+              },
+            ]
+          },
+          {
+            readonly type: 'bytes32'
+          },
+        ]
+        readonly outputs: readonly []
+      },
+    ]
+  >()
 
-  assertType<
+  expectTypeOf<
     ParseAbi<
       [
         'function balanceOf(address owner) view returns (uint256)',
         'event Transfer(address indexed from, address indexed to, uint256 amount)',
       ]
     >
-  >([
-    {
-      name: 'balanceOf',
-      type: 'function',
-      stateMutability: 'view',
-      inputs: [
-        {
-          name: 'owner',
-          type: 'address',
-        },
-      ],
-      outputs: [
-        {
-          type: 'uint256',
-        },
-      ],
-    },
-    {
-      name: 'Transfer',
-      type: 'event',
-      inputs: [
-        {
-          name: 'from',
-          type: 'address',
-          indexed: true,
-        },
-        {
-          name: 'to',
-          type: 'address',
-          indexed: true,
-        },
-        {
-          name: 'amount',
-          type: 'uint256',
-        },
-      ],
-    },
-  ])
+  >().toEqualTypeOf<
+    readonly [
+      {
+        readonly name: 'balanceOf'
+        readonly type: 'function'
+        readonly stateMutability: 'view'
+        readonly inputs: readonly [
+          {
+            readonly name: 'owner'
+            readonly type: 'address'
+          },
+        ]
+        readonly outputs: readonly [
+          {
+            readonly type: 'uint256'
+          },
+        ]
+      },
+      {
+        readonly name: 'Transfer'
+        readonly type: 'event'
+        readonly inputs: readonly [
+          {
+            readonly name: 'from'
+            readonly type: 'address'
+            readonly indexed: true
+          },
+          {
+            readonly name: 'to'
+            readonly type: 'address'
+            readonly indexed: true
+          },
+          {
+            readonly name: 'amount'
+            readonly type: 'uint256'
+          },
+        ]
+      },
+    ]
+  >()
 
   expectTypeOf<ParseAbi<['function foo ()']>>().toEqualTypeOf<never>()
+})
+
+test('parseAbi', () => {
+  // @ts-expect-error empty array not allowed
+  expectTypeOf(parseAbi([])).toEqualTypeOf<never>()
+  expectTypeOf(parseAbi(['struct Foo { string name; }'])).toEqualTypeOf<never>()
+
+  // Array
+  const res2 = parseAbi([
+    'function bar(Foo, bytes32)',
+    'struct Foo { string name; }',
+  ])
+  expectTypeOf<typeof res2>().toEqualTypeOf<
+    readonly [
+      {
+        readonly name: 'bar'
+        readonly type: 'function'
+        readonly stateMutability: 'nonpayable'
+        readonly inputs: readonly [
+          {
+            readonly type: 'tuple'
+            readonly components: readonly [
+              {
+                readonly name: 'name'
+                readonly type: 'string'
+              },
+            ]
+          },
+          {
+            readonly type: 'bytes32'
+          },
+        ]
+        readonly outputs: readonly []
+      },
+    ]
+  >()
+
+  const abi2 = [
+    'function foo()',
+    'function bar(Foo, bytes32)',
+    'struct Foo { string name; }',
+  ]
+  expectTypeOf(parseAbi(abi2)).toEqualTypeOf<Abi>()
+
+  // @ts-expect-error invalid signature
+  expectTypeOf(parseAbi(['function foo ()'])).toEqualTypeOf<never>()
 })

--- a/src/human-readable/parseAbiItem.test-d.ts
+++ b/src/human-readable/parseAbiItem.test-d.ts
@@ -1,4 +1,4 @@
-import { assertType, expectTypeOf, test } from 'vitest'
+import { expectTypeOf, test } from 'vitest'
 
 import type { Abi } from '../abi'
 import type { ParseAbiItem } from './parseAbiItem'
@@ -12,64 +12,67 @@ test('ParseAbiItem', () => {
   >().toEqualTypeOf<never>()
 
   // string
-  assertType<ParseAbiItem<'function foo()'>>({
-    name: 'foo',
-    type: 'function',
-    stateMutability: 'nonpayable',
-    inputs: [],
-    outputs: [],
-  })
+  expectTypeOf<ParseAbiItem<'function foo()'>>().toEqualTypeOf<{
+    readonly name: 'foo'
+    readonly type: 'function'
+    readonly stateMutability: 'nonpayable'
+    readonly inputs: readonly []
+    readonly outputs: readonly []
+  }>()
 
   // Array
-  assertType<
+  expectTypeOf<
     ParseAbiItem<['function bar(Foo, bytes32)', 'struct Foo { string name; }']>
-  >({
-    name: 'bar',
-    type: 'function',
-    stateMutability: 'nonpayable',
-    inputs: [
+  >().toEqualTypeOf<{
+    readonly name: 'bar'
+    readonly type: 'function'
+    readonly stateMutability: 'nonpayable'
+    readonly inputs: readonly [
       {
-        type: 'tuple',
-        components: [
+        readonly type: 'tuple'
+        readonly components: readonly [
           {
-            name: 'name',
-            type: 'string',
+            readonly name: 'name'
+            readonly type: 'string'
           },
-        ],
+        ]
       },
       {
-        type: 'bytes32',
+        readonly type: 'bytes32'
       },
-    ],
-    outputs: [],
-  })
+    ]
+    readonly outputs: readonly []
+  }>()
 
-  assertType<
+  expectTypeOf<
     ParseAbiItem<
       [
         'event Transfer(address indexed from, address indexed to, uint256 amount)',
       ]
     >
-  >({
-    name: 'Transfer',
-    type: 'event',
-    inputs: [
+  >().toEqualTypeOf<{
+    readonly name: 'Transfer'
+    readonly type: 'event'
+    readonly inputs: readonly [
       {
-        name: 'from',
-        type: 'address',
-        indexed: true,
+        readonly name: 'from'
+        readonly type: 'address'
+        readonly indexed: true
       },
       {
-        name: 'to',
-        type: 'address',
-        indexed: true,
+        readonly name: 'to'
+        readonly type: 'address'
+        readonly indexed: true
       },
       {
-        name: 'amount',
-        type: 'uint256',
+        readonly name: 'amount'
+        readonly type: 'uint256'
       },
-    ],
-  })
+    ]
+  }>()
+
+  const abiItem = ['function bar(Foo, bytes32)', 'struct Foo { string name; }']
+  expectTypeOf<ParseAbiItem<typeof abiItem>>().toEqualTypeOf<Abi[number]>()
 
   expectTypeOf<ParseAbiItem<['function foo ()']>>().toEqualTypeOf<never>()
 })
@@ -119,26 +122,26 @@ test('parseAbiItem', () => {
     'function bar(Foo, bytes32)',
     'struct Foo { string name; }',
   ])
-  assertType<typeof res2>({
-    name: 'bar',
-    type: 'function',
-    stateMutability: 'nonpayable',
-    inputs: [
+  expectTypeOf<typeof res2>().toEqualTypeOf<{
+    readonly name: 'bar'
+    readonly type: 'function'
+    readonly stateMutability: 'nonpayable'
+    readonly inputs: readonly [
       {
-        type: 'tuple',
-        components: [
+        readonly type: 'tuple'
+        readonly components: readonly [
           {
-            name: 'name',
-            type: 'string',
+            readonly name: 'name'
+            readonly type: 'string'
           },
-        ],
+        ]
       },
       {
-        type: 'bytes32',
+        readonly type: 'bytes32'
       },
-    ],
-    outputs: [],
-  })
+    ]
+    readonly outputs: readonly []
+  }>()
 
   const abi2 = [
     'function foo()',

--- a/src/human-readable/parseAbiItem.test.ts
+++ b/src/human-readable/parseAbiItem.test.ts
@@ -14,9 +14,9 @@ test('parseAbiItem', () => {
   // @ts-expect-error invalid signature type
   expect(() => parseAbiItem([])).toThrowErrorMatchingInlineSnapshot(
     `
-    "Failed to parse ABI Item.
+    "Failed to parse ABI item.
 
-    Docs: https://abitype.dev/todo
+    Docs: https://abitype.dev/api/human.html#parseabiitem-1
     Details: parseAbiItem([])
     Version: abitype@x.y.z"
   `,
@@ -25,9 +25,9 @@ test('parseAbiItem', () => {
     parseAbiItem(['struct Foo { string name; }']),
   ).toThrowErrorMatchingInlineSnapshot(
     `
-    "Failed to parse ABI Item.
+    "Failed to parse ABI item.
 
-    Docs: https://abitype.dev/todo
+    Docs: https://abitype.dev/api/human.html#parseabiitem-1
     Details: parseAbiItem([
       \\"struct Foo { string name; }\\"
     ])
@@ -38,7 +38,7 @@ test('parseAbiItem', () => {
 
 test.each([
   {
-    signatures: ['function foo(string)'],
+    signature: ['function foo(string)'],
     expected: {
       type: 'function',
       name: 'foo',
@@ -48,7 +48,7 @@ test.each([
     },
   },
   {
-    signatures: [
+    signature: [
       'event Foo(address indexed from, address indexed to, uint256 amount)',
     ],
     expected: {
@@ -61,13 +61,13 @@ test.each([
       ],
     },
   },
-])(`parseAbiItem($signatures)`, ({ signatures, expected }) => {
-  expect(parseAbiItem(signatures)).toEqual(expected)
+])(`parseAbiItem($signature)`, ({ signature, expected }) => {
+  expect(parseAbiItem(signature)).toEqual(expected)
 })
 
 test.each([
   {
-    signatures: ['struct Foo { string bar; }', 'function foo(Foo)'],
+    signature: ['struct Foo { string bar; }', 'function foo(Foo)'],
     expected: {
       type: 'function',
       name: 'foo',
@@ -78,6 +78,6 @@ test.each([
       stateMutability: 'nonpayable',
     },
   },
-])(`parseAbiItem($signatures)`, ({ signatures, expected }) => {
-  expect(parseAbiItem(signatures)).toEqual(expected)
+])(`parseAbiItem($signature)`, ({ signature, expected }) => {
+  expect(parseAbiItem(signature)).toEqual(expected)
 })

--- a/src/human-readable/parseAbiItem.ts
+++ b/src/human-readable/parseAbiItem.ts
@@ -1,11 +1,9 @@
 import type { Abi } from '../abi'
 import type { Narrow } from '../narrow'
-import type { Filter } from '../types'
+import type { Error, Filter } from '../types'
 import { BaseError } from './errors'
-import { isStructSignature, parseStructs } from './runtime'
-import { parseSignature } from './runtime/utils'
+import { isStructSignature, parseSignature, parseStructs } from './runtime'
 import type {
-  IsSignature,
   ParseSignature,
   ParseStructs,
   Signature,
@@ -30,34 +28,38 @@ import type {
  */
 export type ParseAbiItem<
   TSignature extends string | readonly string[] | readonly unknown[],
-> = TSignature extends string
-  ? TSignature extends Signature<TSignature> // Validate signature
-    ? ParseSignature<TSignature>
-    : never
-  : string[] extends TSignature
-  ? Abi[number] // Return generic Abi item since type was no inferrable
-  : TSignature extends readonly string[]
-  ? TSignature extends Signatures<TSignature> // Validate signatures
-    ? ParseStructs<TSignature> extends infer Structs
-      ? {
-          [K in keyof TSignature]: TSignature[K] extends string
-            ? ParseSignature<TSignature[K], Structs>
+> =
+  | (TSignature extends string
+      ? TSignature extends Signature<TSignature> // Validate signature
+        ? ParseSignature<TSignature>
+        : never
+      : never)
+  | (TSignature extends readonly string[]
+      ? string[] extends TSignature
+        ? Abi[number] // Return generic Abi item since type was no inferrable
+        : TSignature extends Signatures<TSignature> // Validate signature
+        ? ParseStructs<TSignature> extends infer Structs
+          ? {
+              [K in keyof TSignature]: ParseSignature<
+                TSignature[K] extends string ? TSignature[K] : never,
+                Structs
+              >
+            } extends infer Mapped extends readonly unknown[]
+            ? // Filter out `never` since those are structs
+              Filter<Mapped, never>[0] extends infer Result
+              ? Result extends undefined // convert `undefined` to `never` (e.g. `ParseAbiItem<['struct Foo { string name; }']>`)
+                ? never
+                : Result
+              : never
             : never
-        } extends infer Mapped extends readonly unknown[]
-        ? Filter<Mapped, never>[0] extends infer Result
-          ? Result extends undefined
-            ? never
-            : Result
           : never
         : never
-      : never
-    : never
-  : never
+      : never)
 
 /**
  * Parses human-readable ABI item (e.g. error, event, function) into {@link Abi} item
  *
- * @param signatures - Human-readable ABI item
+ * @param signature - Human-readable ABI item
  * @returns Parsed {@link Abi} item
  *
  * @example
@@ -74,39 +76,40 @@ export type ParseAbiItem<
 export function parseAbiItem<
   TSignature extends string | readonly string[] | readonly unknown[],
 >(
-  signatures: Narrow<TSignature> &
-    (TSignature extends readonly []
-      ? never
-      : string[] extends TSignature
-      ? unknown
-      : TSignature extends string
-      ? IsSignature<TSignature> extends true
-        ? unknown
-        : never
-      : TSignature extends Signatures<
-          TSignature extends readonly string[] ? TSignature : never
-        >
-      ? unknown
-      : never),
+  signature: Narrow<TSignature> &
+    (
+      | (TSignature extends string
+          ? string extends TSignature
+            ? unknown
+            : Signature<TSignature>
+          : never)
+      | (TSignature extends readonly string[]
+          ? TSignature extends readonly [] // empty array
+            ? Error<'At least one signature required.'>
+            : string[] extends TSignature
+            ? unknown
+            : Signatures<TSignature>
+          : never)
+    ),
 ): ParseAbiItem<TSignature> {
   let abiItem
-  if (typeof signatures === 'string')
-    abiItem = parseSignature(signatures) as ParseAbiItem<TSignature>
+  if (typeof signature === 'string')
+    abiItem = parseSignature(signature) as ParseAbiItem<TSignature>
   else {
-    const structs = parseStructs(signatures as readonly string[])
-    const length = signatures.length
+    const structs = parseStructs(signature as readonly string[])
+    const length = signature.length
     for (let i = 0; i < length; i++) {
-      const signature = (signatures as readonly string[])[i]!
-      if (isStructSignature(signature)) continue
-      abiItem = parseSignature(signature, structs)
+      const signature_ = (signature as readonly string[])[i]!
+      if (isStructSignature(signature_)) continue
+      abiItem = parseSignature(signature_, structs)
       break
     }
   }
 
   if (!abiItem)
-    throw new BaseError('Failed to parse ABI Item.', {
-      details: `parseAbiItem(${JSON.stringify(signatures, null, 2)})`,
-      docsPath: '/todo',
+    throw new BaseError('Failed to parse ABI item.', {
+      details: `parseAbiItem(${JSON.stringify(signature, null, 2)})`,
+      docsPath: '/api/human.html#parseabiitem-1',
     })
   return abiItem as ParseAbiItem<TSignature>
 }

--- a/src/human-readable/parseAbiParameter.test-d.ts
+++ b/src/human-readable/parseAbiParameter.test-d.ts
@@ -1,6 +1,7 @@
-import { assertType, expectTypeOf, test } from 'vitest'
+import { expectTypeOf, test } from 'vitest'
 
 import type { ParseAbiParameter } from './parseAbiParameter'
+import { parseAbiParameter } from './parseAbiParameter'
 
 test('ParseAbiParameter', () => {
   expectTypeOf<ParseAbiParameter<''>>().toEqualTypeOf<never>()
@@ -10,30 +11,32 @@ test('ParseAbiParameter', () => {
   >().toEqualTypeOf<never>()
 
   // string
-  assertType<ParseAbiParameter<'address from'>>({
-    type: 'address',
-    name: 'from',
-  })
-  assertType<ParseAbiParameter<'address indexed from'>>({
-    type: 'address',
-    name: 'from',
-    indexed: true,
-  })
-  assertType<ParseAbiParameter<'address calldata foo'>>({
-    type: 'address',
-    name: 'foo',
-  })
+  expectTypeOf<ParseAbiParameter<'address from'>>().toEqualTypeOf<{
+    readonly type: 'address'
+    readonly name: 'from'
+  }>()
+  expectTypeOf<ParseAbiParameter<'address indexed from'>>().toEqualTypeOf<{
+    readonly type: 'address'
+    readonly name: 'from'
+    readonly indexed: true
+  }>()
+  expectTypeOf<ParseAbiParameter<'address calldata foo'>>().toEqualTypeOf<{
+    readonly type: 'address'
+    readonly name: 'foo'
+  }>()
 
   // Array
-  assertType<ParseAbiParameter<['Foo', 'struct Foo { string name; }']>>({
-    type: 'tuple',
-    components: [
+  expectTypeOf<
+    ParseAbiParameter<['Foo', 'struct Foo { string name; }']>
+  >().toEqualTypeOf<{
+    readonly type: 'tuple'
+    readonly components: readonly [
       {
-        name: 'name',
-        type: 'string',
+        readonly name: 'name'
+        readonly type: 'string'
       },
-    ],
-  })
+    ]
+  }>()
 
   expectTypeOf<ParseAbiParameter<'(string bar) foo'>>().toEqualTypeOf<{
     readonly type: 'tuple'
@@ -44,5 +47,18 @@ test('ParseAbiParameter', () => {
       },
     ]
     readonly name: 'foo'
+  }>()
+})
+
+test('parseAbiParameter', () => {
+  // @ts-expect-error empty array not allowed
+  expectTypeOf(parseAbiParameter([])).toEqualTypeOf<never>()
+  expectTypeOf(
+    parseAbiParameter(['struct Foo { string name; }']),
+  ).toEqualTypeOf<never>()
+
+  expectTypeOf(parseAbiParameter('(string)')).toEqualTypeOf<{
+    readonly type: 'tuple'
+    readonly components: readonly [{ readonly type: 'string' }]
   }>()
 })

--- a/src/human-readable/parseAbiParameter.test.ts
+++ b/src/human-readable/parseAbiParameter.test.ts
@@ -14,9 +14,9 @@ test('parseAbiParameter', () => {
   // @ts-expect-error invalid signature type
   expect(() => parseAbiParameter([])).toThrowErrorMatchingInlineSnapshot(
     `
-    "Failed to parse ABI Item.
+    "Failed to parse ABI parameter.
 
-    Docs: https://abitype.dev/todo
+    Docs: https://abitype.dev/api/human.html#parseabiparameter-1
     Details: parseAbiParameter([])
     Version: abitype@x.y.z"
   `,
@@ -25,9 +25,9 @@ test('parseAbiParameter', () => {
     parseAbiParameter(['struct Foo { string name; }']),
   ).toThrowErrorMatchingInlineSnapshot(
     `
-    "Failed to parse ABI Item.
+    "Failed to parse ABI parameter.
 
-    Docs: https://abitype.dev/todo
+    Docs: https://abitype.dev/api/human.html#parseabiparameter-1
     Details: parseAbiParameter([
       \\"struct Foo { string name; }\\"
     ])
@@ -144,31 +144,31 @@ test('nested tuple', () => {
       "type": "tuple",
     }
   `)
-  assertType<typeof result>({
-    type: 'tuple',
-    components: [
+  assertType<{
+    type: 'tuple'
+    components: readonly [
       {
-        type: 'tuple',
-        components: [
+        type: 'tuple'
+        components: readonly [
           {
-            type: 'tuple[1]',
-            components: [
+            type: 'tuple[1]'
+            components: readonly [
               {
-                type: 'tuple',
-                components: [
+                type: 'tuple'
+                components: readonly [
                   {
-                    type: 'string',
-                    name: 'baz',
+                    type: 'string'
+                    name: 'baz'
                   },
-                ],
-                name: 'bar',
+                ]
+                name: 'bar'
               },
-            ],
-            name: 'foo',
+            ]
+            name: 'foo'
           },
-        ],
-        name: 'boo',
+        ]
+        name: 'boo'
       },
-    ],
-  })
+    ]
+  }>(result)
 })

--- a/src/human-readable/parseAbiParameter.ts
+++ b/src/human-readable/parseAbiParameter.ts
@@ -1,6 +1,6 @@
 import type { AbiParameter } from '../abi'
 import type { Narrow } from '../narrow'
-import type { Filter } from '../types'
+import type { Error, Filter } from '../types'
 import { BaseError } from './errors'
 import {
   isStructSignature,
@@ -33,32 +33,34 @@ import { modifiers } from './types'
  */
 export type ParseAbiParameter<
   TParam extends string | readonly string[] | readonly unknown[],
-> = TParam extends string
-  ? TParam extends ''
-    ? never
-    : ParseAbiParameter_<TParam, { Modifier: Modifier }>
-  : string[] extends TParam
-  ? AbiParameter // Return generic AbiParameter item since type was no inferrable
-  : TParam extends readonly string[]
-  ? ParseStructs<TParam> extends infer Structs
-    ? {
-        [K in keyof TParam]: TParam[K] extends string
-          ? IsStructSignature<TParam[K]> extends true
-            ? never
-            : ParseAbiParameter_<
-                TParam[K],
-                { Modifier: Modifier; Structs: Structs }
-              >
+> =
+  | (TParam extends string
+      ? TParam extends ''
+        ? never
+        : ParseAbiParameter_<TParam, { Modifier: Modifier }>
+      : never)
+  | (TParam extends readonly string[]
+      ? string[] extends TParam
+        ? AbiParameter // Return generic AbiParameter item since type was no inferrable
+        : ParseStructs<TParam> extends infer Structs
+        ? {
+            [K in keyof TParam]: TParam[K] extends string
+              ? IsStructSignature<TParam[K]> extends true
+                ? never
+                : ParseAbiParameter_<
+                    TParam[K],
+                    { Modifier: Modifier; Structs: Structs }
+                  >
+              : never
+          } extends infer Mapped extends readonly unknown[]
+          ? Filter<Mapped, never>[0] extends infer Result
+            ? Result extends undefined
+              ? never
+              : Result
+            : never
           : never
-      } extends infer Mapped extends readonly unknown[]
-      ? Filter<Mapped, never>[0] extends infer Result
-        ? Result extends undefined
-          ? never
-          : Result
         : never
-      : never
-    : never
-  : never
+      : never)
 
 /**
  * Parses human-readable ABI parameter into {@link AbiParameter}
@@ -81,17 +83,20 @@ export function parseAbiParameter<
   TParam extends string | readonly string[] | readonly unknown[],
 >(
   param: Narrow<TParam> &
-    (TParam extends readonly []
-      ? never
-      : string[] extends TParam
-      ? unknown
-      : TParam extends string
-      ? TParam extends ''
-        ? never
-        : unknown
-      : TParam extends readonly string[]
-      ? unknown
-      : never),
+    (
+      | (TParam extends string
+          ? TParam extends ''
+            ? Error<'Empty string is not allowed.'>
+            : unknown
+          : never)
+      | (TParam extends readonly string[]
+          ? TParam extends readonly [] // empty array
+            ? Error<'At least one parameter required.'>
+            : string[] extends TParam
+            ? unknown
+            : unknown // TODO: Validate param string
+          : never)
+    ),
 ): ParseAbiParameter<TParam> {
   let abiParameter
   if (typeof param === 'string')
@@ -110,9 +115,9 @@ export function parseAbiParameter<
   }
 
   if (!abiParameter)
-    throw new BaseError('Failed to parse ABI Item.', {
+    throw new BaseError('Failed to parse ABI parameter.', {
       details: `parseAbiParameter(${JSON.stringify(param, null, 2)})`,
-      docsPath: '/todo',
+      docsPath: '/api/human.html#parseabiparameter-1',
     })
   return abiParameter as ParseAbiParameter<TParam>
 }

--- a/src/human-readable/parseAbiParameters.test-d.ts
+++ b/src/human-readable/parseAbiParameters.test-d.ts
@@ -1,6 +1,7 @@
-import { assertType, expectTypeOf, test } from 'vitest'
+import { expectTypeOf, test } from 'vitest'
 
 import type { ParseAbiParameters } from './parseAbiParameters'
+import { parseAbiParameters } from './parseAbiParameters'
 
 test('ParseAbiParameters', () => {
   expectTypeOf<ParseAbiParameters<''>>().toEqualTypeOf<never>()
@@ -10,69 +11,96 @@ test('ParseAbiParameters', () => {
   >().toEqualTypeOf<never>()
 
   // string
-  assertType<ParseAbiParameters<'address from, address to, uint256 amount'>>([
-    {
-      type: 'address',
-      name: 'from',
-    },
-    {
-      type: 'address',
-      name: 'to',
-    },
-    {
-      type: 'uint256',
-      name: 'amount',
-    },
-  ])
-  assertType<
+  expectTypeOf<
+    ParseAbiParameters<'address from, address to, uint256 amount'>
+  >().toEqualTypeOf<
+    readonly [
+      {
+        readonly type: 'address'
+        readonly name: 'from'
+      },
+      {
+        readonly type: 'address'
+        readonly name: 'to'
+      },
+      {
+        readonly type: 'uint256'
+        readonly name: 'amount'
+      },
+    ]
+  >()
+  expectTypeOf<
     ParseAbiParameters<'address indexed from, address indexed to, uint256 indexed amount'>
-  >([
-    {
-      type: 'address',
-      name: 'from',
-      indexed: true,
-    },
-    {
-      type: 'address',
-      name: 'to',
-      indexed: true,
-    },
-    {
-      type: 'uint256',
-      name: 'amount',
-      indexed: true,
-    },
-  ])
-  assertType<
+  >().toEqualTypeOf<
+    readonly [
+      {
+        readonly type: 'address'
+        readonly name: 'from'
+        readonly indexed: true
+      },
+      {
+        readonly type: 'address'
+        readonly name: 'to'
+        readonly indexed: true
+      },
+      {
+        readonly type: 'uint256'
+        readonly name: 'amount'
+        readonly indexed: true
+      },
+    ]
+  >()
+  expectTypeOf<
     ParseAbiParameters<'address calldata foo, address memory bar, uint256 storage baz'>
-  >([
-    {
-      type: 'address',
-      name: 'foo',
-    },
-    {
-      type: 'address',
-      name: 'bar',
-    },
-    {
-      type: 'uint256',
-      name: 'baz',
-    },
-  ])
+  >().toEqualTypeOf<
+    readonly [
+      {
+        readonly type: 'address'
+        readonly name: 'foo'
+      },
+      {
+        readonly type: 'address'
+        readonly name: 'bar'
+      },
+      {
+        readonly type: 'uint256'
+        readonly name: 'baz'
+      },
+    ]
+  >()
 
   // Array
-  assertType<
+  expectTypeOf<
     ParseAbiParameters<['Foo, bytes32', 'struct Foo { string name; }']>
-  >([
-    {
-      type: 'tuple',
-      components: [
-        {
-          name: 'name',
-          type: 'string',
-        },
-      ],
-    },
-    { type: 'bytes32' },
-  ])
+  >().toEqualTypeOf<
+    readonly [
+      {
+        readonly type: 'tuple'
+        readonly components: readonly [
+          {
+            readonly name: 'name'
+            readonly type: 'string'
+          },
+        ]
+      },
+      { readonly type: 'bytes32' },
+    ]
+  >()
+})
+
+test('parseAbiParameters', () => {
+  // @ts-expect-error empty array not allowed
+  expectTypeOf(parseAbiParameters([])).toEqualTypeOf<never>()
+  expectTypeOf(
+    parseAbiParameters(['struct Foo { string name; }']),
+  ).toEqualTypeOf<never>()
+
+  expectTypeOf(parseAbiParameters('(string)')).toEqualTypeOf<
+    readonly [
+      {
+        readonly type: 'tuple'
+        readonly components: readonly [{ readonly type: 'string' }]
+      },
+    ]
+  >()
 })

--- a/src/human-readable/parseAbiParameters.test.ts
+++ b/src/human-readable/parseAbiParameters.test.ts
@@ -6,9 +6,9 @@ test('parseAbiParameters', () => {
   // @ts-expect-error invalid signature type
   expect(() => parseAbiParameters('')).toThrowErrorMatchingInlineSnapshot(
     `
-    "Failed to parse ABI Item.
+    "Failed to parse ABI parameters.
 
-    Docs: https://abitype.dev/todo
+    Docs: https://abitype.dev/api/human.html#parseabiparameters-1
     Details: parseAbiParameters(\\"\\")
     Version: abitype@x.y.z"
   `,
@@ -16,9 +16,9 @@ test('parseAbiParameters', () => {
   // @ts-expect-error invalid signature type
   expect(() => parseAbiParameters([])).toThrowErrorMatchingInlineSnapshot(
     `
-    "Failed to parse ABI Item.
+    "Failed to parse ABI parameters.
 
-    Docs: https://abitype.dev/todo
+    Docs: https://abitype.dev/api/human.html#parseabiparameters-1
     Details: parseAbiParameters([])
     Version: abitype@x.y.z"
   `,
@@ -27,9 +27,9 @@ test('parseAbiParameters', () => {
     parseAbiParameters(['struct Foo { string name; }']),
   ).toThrowErrorMatchingInlineSnapshot(
     `
-    "Failed to parse ABI Item.
+    "Failed to parse ABI parameters.
 
-    Docs: https://abitype.dev/todo
+    Docs: https://abitype.dev/api/human.html#parseabiparameters-1
     Details: parseAbiParameters([
       \\"struct Foo { string name; }\\"
     ])

--- a/src/human-readable/runtime/index.ts
+++ b/src/human-readable/runtime/index.ts
@@ -2,4 +2,4 @@ export { isStructSignature } from './signatures'
 
 export { parseStructs } from './structs'
 
-export { parseAbiParameter, splitParameters } from './utils'
+export { parseAbiParameter, parseSignature, splitParameters } from './utils'

--- a/src/human-readable/types/signatures-test-d.ts
+++ b/src/human-readable/types/signatures-test-d.ts
@@ -116,14 +116,14 @@ test('IsSignature', () => {
 
 test('Signature', () => {
   assertType<Signature<'function foo()'>>('function foo()')
-  assertType<Signature<'function foo ()'>>(
-    'Error: Signature "function foo ()" is invalid',
-  )
+  assertType<Signature<'function foo ()'>>([
+    'Error: Signature "function foo ()" is invalid.',
+  ])
 })
 
 test('Signatures', () => {
   assertType<Signatures<['function foo()']>>(['function foo()'])
   assertType<Signatures<['function foo ()']>>([
-    'Error: Signature "function foo ()" is invalid at position 0',
+    ['Error: Signature "function foo ()" is invalid at position 0.'],
   ])
 })

--- a/src/human-readable/types/signatures.ts
+++ b/src/human-readable/types/signatures.ts
@@ -28,19 +28,18 @@ export type FunctionSignature<
   TName extends string = string,
   TTail extends string = string,
 > = `function ${TName}(${TTail}`
-export type IsFunctionSignature<T> =
-  T extends `function ${infer Name}(${string}`
-    ? IsName<Name> extends true
-      ? T extends ValidFunctionSignatures
-        ? true
-        : // Check that `Parameters` is not absorbing other types (e.g. `returns`)
-        T extends `function ${string}(${infer Parameters})`
-        ? Parameters extends InvalidFunctionParameters
-          ? false
-          : true
-        : false
+export type IsFunctionSignature<T> = T extends FunctionSignature<infer Name>
+  ? IsName<Name> extends true
+    ? T extends ValidFunctionSignatures
+      ? true
+      : // Check that `Parameters` is not absorbing other types (e.g. `returns`)
+      T extends `function ${string}(${infer Parameters})`
+      ? Parameters extends InvalidFunctionParameters
+        ? false
+        : true
       : false
     : false
+  : false
 export type Scope = 'public' | 'external' // `internal` or `private` functions wouldn't make it to ABI so can ignore
 type Returns = `returns (${string})`
 // Almost all valid function signatures, except `function ${string}(${infer Parameters})` since `Parameters` can absorb returns
@@ -101,7 +100,7 @@ export type Signature<
   ? T
   : Error<`Signature "${T}" is invalid${K extends string
       ? ` at position ${K}`
-      : ''}`>
+      : ''}.`>
 
 export type Signatures<T extends readonly string[]> = {
   [K in keyof T]: Signature<T[K], K>

--- a/src/human-readable/types/structs.test-d.ts
+++ b/src/human-readable/types/structs.test-d.ts
@@ -1,4 +1,4 @@
-import { assertType, expectTypeOf, test } from 'vitest'
+import { expectTypeOf, test } from 'vitest'
 
 import type {
   ParseStruct,
@@ -17,103 +17,120 @@ test('ParseStructs', () => {
       'function addPerson(Person person)',
     ]
   >
-  assertType<Result>({
-    Name: [
+  expectTypeOf<Result>().toEqualTypeOf<{
+    Name: readonly [
       {
-        type: 'tuple',
-        name: 'foo',
-        components: [{ type: 'string', name: 'bar' }],
+        readonly type: 'tuple'
+        readonly name: 'foo'
+        readonly components: readonly [{ type: 'string'; name: 'bar' }]
       },
-    ],
-    Foo: [{ type: 'string', name: 'bar' }],
-    Person: [
+    ]
+    Foo: readonly [{ readonly type: 'string'; readonly name: 'bar' }]
+    Person: readonly [
       {
-        type: 'tuple',
-        name: 'name',
-        components: [
+        readonly type: 'tuple'
+        readonly name: 'name'
+        readonly components: readonly [
           {
-            type: 'tuple',
-            name: 'foo',
-            components: [{ type: 'string', name: 'bar' }],
+            readonly type: 'tuple'
+            readonly name: 'foo'
+            readonly components: [
+              { readonly type: 'string'; readonly name: 'bar' },
+            ]
           },
-        ],
+        ]
       },
-    ],
-  })
+    ]
+  }>()
 
-  assertType<
+  expectTypeOf<
     ParseStructs<['struct Foo { Bar bar; }', 'struct Bar { Foo foo; }']>
-  >({
-    Foo: [
+  >().toEqualTypeOf<{
+    Foo: readonly [
       {
-        name: 'bar',
-        type: 'tuple',
-        components: [
+        readonly name: 'bar'
+        readonly type: 'tuple'
+        readonly components: readonly [
           {
-            name: 'foo',
-            type: 'tuple',
-            components: [
-              'Error: Circular reference detected. Struct "Bar" is a circular reference.',
-            ],
+            readonly name: 'foo'
+            readonly type: 'tuple'
+            readonly components: readonly [
+              [
+                'Error: Circular reference detected. Struct "Bar" is a circular reference.',
+              ],
+            ]
           },
-        ],
+        ]
       },
-    ],
-    Bar: [
+    ]
+    Bar: readonly [
       {
-        name: 'foo',
-        type: 'tuple',
-        components: [
+        readonly name: 'foo'
+        readonly type: 'tuple'
+        readonly components: readonly [
           {
-            name: 'bar',
-            type: 'tuple',
-            components: [
-              'Error: Circular reference detected. Struct "Foo" is a circular reference.',
-            ],
+            readonly name: 'bar'
+            readonly type: 'tuple'
+            readonly components: readonly [
+              [
+                'Error: Circular reference detected. Struct "Foo" is a circular reference.',
+              ],
+            ]
           },
-        ],
+        ]
       },
-    ],
-  })
+    ]
+  }>()
 
-  assertType<ParseStructs<['struct Foo { Foo foo; }']>>({
-    Foo: [
+  expectTypeOf<ParseStructs<['struct Foo { Foo foo; }']>>().toEqualTypeOf<{
+    Foo: readonly [
       {
-        name: 'foo',
-        type: 'tuple',
-        components: [
-          'Error: Circular reference detected. Struct "Foo" is a circular reference.',
-        ],
+        readonly name: 'foo'
+        readonly type: 'tuple'
+        readonly components: readonly [
+          [
+            'Error: Circular reference detected. Struct "Foo" is a circular reference.',
+          ],
+        ]
       },
-    ],
-  })
+    ]
+  }>()
 
-  assertType<ParseStructs<['struct Person { Name name;']>>({})
-  assertType<ParseStructs<[]>>({})
-  assertType<ParseStructs<['function addPerson(Person person)']>>({})
+  expectTypeOf<
+    ParseStructs<['struct Person { Name name;']>
+    // eslint-disable-next-line @typescript-eslint/ban-types
+  >().toEqualTypeOf<{}>()
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  expectTypeOf<ParseStructs<[]>>().toEqualTypeOf<{}>()
+  expectTypeOf<
+    ParseStructs<['function addPerson(Person person)']>
+    // eslint-disable-next-line @typescript-eslint/ban-types
+  >().toEqualTypeOf<{}>()
 })
 
 test('ParseStruct', () => {
-  assertType<ParseStruct<'struct Foo { string foo; string bar; }'>>({
-    name: 'Foo',
-    components: [
-      { type: 'string', name: 'foo' },
-      { type: 'string', name: 'bar' },
-    ],
-  })
-  assertType<ParseStruct<'struct Foo {}'>>({
-    name: 'Foo',
-    components: [],
-  })
-  assertType<ParseStruct<'struct Foo { Bar bar; }'>>({
-    name: 'Foo',
-    components: [
+  expectTypeOf<
+    ParseStruct<'struct Foo { string foo; string bar; }'>
+  >().toEqualTypeOf<{
+    readonly name: 'Foo'
+    readonly components: [
+      { type: 'string'; name: 'foo' },
+      { type: 'string'; name: 'bar' },
+    ]
+  }>()
+  expectTypeOf<ParseStruct<'struct Foo {}'>>().toEqualTypeOf<{
+    readonly name: 'Foo'
+    readonly components: []
+  }>()
+  expectTypeOf<ParseStruct<'struct Foo { Bar bar; }'>>().toEqualTypeOf<{
+    readonly name: 'Foo'
+    readonly components: [
       {
-        type: 'Bar',
-        name: 'bar',
+        type: 'Bar'
+        name: 'bar'
       },
-    ],
-  })
+    ]
+  }>()
 
   expectTypeOf<ParseStruct<''>>().toEqualTypeOf<never>()
   expectTypeOf<ParseStruct<'function foo()'>>().toEqualTypeOf<never>()
@@ -128,35 +145,37 @@ test('ResolveStructs', () => {
       Foo: [{ type: 'string'; name: 'bar' }, { type: 'uint16'; name: 'baz' }]
     }
   >
-  assertType<Result>([
-    {
-      type: 'tuple',
-      name: 'name',
-      components: [
-        {
-          type: 'tuple',
-          name: 'foo',
-          components: [
-            { type: 'string', name: 'bar' },
-            { type: 'uint16', name: 'baz' },
-          ],
-        },
-      ],
-    },
-  ])
+  expectTypeOf<Result>().toEqualTypeOf<
+    readonly [
+      {
+        readonly type: 'tuple'
+        readonly name: 'name'
+        readonly components: readonly [
+          {
+            readonly type: 'tuple'
+            readonly name: 'foo'
+            readonly components: readonly [
+              { readonly type: 'string'; readonly name: 'bar' },
+              { readonly type: 'uint16'; readonly name: 'baz' },
+            ]
+          },
+        ]
+      },
+    ]
+  >()
 
-  expectTypeOf<ResolveStructs<[], StructLookup>>().toEqualTypeOf<[]>()
+  expectTypeOf<ResolveStructs<[], StructLookup>>().toEqualTypeOf<readonly []>()
   expectTypeOf<
     ResolveStructs<
       [{ type: 'Foo[]'; name: 'foo' }],
       { Foo: [{ type: 'string'; name: 'bar' }] }
     >
   >().toEqualTypeOf<
-    [
+    readonly [
       {
-        name: 'foo'
-        type: 'tuple[]'
-        components: [
+        readonly name: 'foo'
+        readonly type: 'tuple[]'
+        readonly components: readonly [
           {
             type: 'string'
             name: 'bar'
@@ -168,20 +187,24 @@ test('ResolveStructs', () => {
 })
 
 test('ParseStructProperties', () => {
-  assertType<ParseStructProperties<'string;'>>([{ type: 'string' }])
-  assertType<ParseStructProperties<'string foo;'>>([
-    { type: 'string', name: 'foo' },
-  ])
-  assertType<ParseStructProperties<'string; string;'>>([
-    { type: 'string' },
-    { type: 'string' },
-  ])
-  assertType<ParseStructProperties<'string foo; string bar;'>>([
-    { type: 'string', name: 'foo' },
-    { type: 'string', name: 'bar' },
-  ])
+  expectTypeOf<ParseStructProperties<'string;'>>().toEqualTypeOf<
+    [{ type: 'string' }]
+  >()
+  expectTypeOf<ParseStructProperties<'string foo;'>>().toEqualTypeOf<
+    [{ type: 'string'; name: 'foo' }]
+  >()
+  expectTypeOf<ParseStructProperties<'string; string;'>>().toEqualTypeOf<
+    [{ type: 'string' }, { type: 'string' }]
+  >()
+  expectTypeOf<
+    ParseStructProperties<'string foo; string bar;'>
+  >().toEqualTypeOf<
+    [{ type: 'string'; name: 'foo' }, { type: 'string'; name: 'bar' }]
+  >()
 
-  assertType<ParseStructProperties<''>>([])
-  assertType<ParseStructProperties<'string'>>([])
-  assertType<ParseStructProperties<'string; string'>>([{ type: 'string' }])
+  expectTypeOf<ParseStructProperties<''>>().toEqualTypeOf<[]>()
+  expectTypeOf<ParseStructProperties<'string'>>().toEqualTypeOf<[]>()
+  expectTypeOf<ParseStructProperties<'string; string'>>().toEqualTypeOf<
+    [{ type: 'string' }]
+  >()
 })

--- a/src/types.test-d.ts
+++ b/src/types.test-d.ts
@@ -11,13 +11,13 @@ import type {
 } from './types'
 
 test('Error', () => {
-  expectTypeOf<
-    Error<'Custom error message'>
-  >().toEqualTypeOf<'Error: Custom error message'>()
+  expectTypeOf<Error<'Custom error message'>>().toEqualTypeOf<
+    ['Error: Custom error message']
+  >()
   expectTypeOf<
     Error<['Custom error message', 'Another custom message']>
   >().toEqualTypeOf<
-    'Error: Custom error message' | 'Error: Another custom message'
+    ['Error: Custom error message', 'Error: Another custom message']
   >()
 })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,11 +6,18 @@
  *
  * @example
  * type Result = Error<'Custom error message'>
- * //   ^? type Result = 'Error: Custom error message'
+ * //   ^? type Result = ['Error: Custom error message']
  */
-export type Error<T extends string | string[]> = `Error: ${T extends string
-  ? T
-  : T[number]}`
+export type Error<T extends string | string[]> = T extends string
+  ? [
+      // Surrounding with array to prevent `T` from being widened to `string`
+      `Error: ${T}`,
+    ]
+  : {
+      [K in keyof T]: T[K] extends infer Message extends string
+        ? `Error: ${Message}`
+        : never
+    }
 
 /**
  * Filters out all members of {@link T} that are {@link P}

--- a/src/utils.test-d.ts
+++ b/src/utils.test-d.ts
@@ -808,8 +808,9 @@ test('TypedDataToPrimitiveTypes', () => {
       type Result = TypedDataToPrimitiveTypes<typeof types>
       assertType<Result>({
         Name: {
-          first:
+          first: [
             "Error: Cannot convert self-referencing struct 'Name' to primitive type.",
+          ],
           last: 'Meagher',
         },
       })
@@ -825,14 +826,18 @@ test('TypedDataToPrimitiveTypes', () => {
         Foo: {
           bar: {
             foo: {
-              bar: "Error: Circular reference detected. 'Bar' is a circular reference.",
+              bar: [
+                "Error: Circular reference detected. 'Bar' is a circular reference.",
+              ],
             },
           },
         },
         Bar: {
           foo: {
             bar: {
-              foo: "Error: Circular reference detected. 'Foo' is a circular reference.",
+              foo: [
+                "Error: Circular reference detected. 'Foo' is a circular reference.",
+              ],
             },
           },
         },
@@ -849,7 +854,9 @@ test('TypedDataToPrimitiveTypes', () => {
       type Result = TypedDataToPrimitiveTypes<typeof types>
       assertType<Result>({
         Name: {
-          first: "Error: Cannot convert unknown type 'Foo' to primitive type.",
+          first: [
+            "Error: Cannot convert unknown type 'Foo' to primitive type.",
+          ],
           last: 'Meagher',
         },
       })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -348,7 +348,6 @@ export type IsTypedData<TTypedData> = TTypedData extends TypedData
  * @param TAbiParameterKind - Optional {@link AbiParameterKind} to narrow by parameter type
  * @returns Union of TypeScript primitive types
  */
-// TODO: Check for recursive structs (e.g. add generic slot for recursion)
 export type TypedDataToPrimitiveTypes<
   TTypedData extends TypedData,
   TAbiParameterKind extends AbiParameterKind = AbiParameterKind,


### PR DESCRIPTION
## Description

Cleans up `parse*(…)` and `Parse*<…>` types

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
