### PR TITLE
refactor: change TypedDataDomain chainId type

### DIFF
--- a/.changeset/many-bottles-explode.md
+++ b/.changeset/many-bottles-explode.md
@@ -1,0 +1,5 @@
+---
+'abitype': minor
+---
+
+Changed `TypedDataDomain['chainId']` to `number`.

--- a/src/abi.ts
+++ b/src/abi.ts
@@ -214,7 +214,7 @@ export type Abi = readonly (
 // Typed Data Types
 
 export type TypedDataDomain = {
-  chainId?: string | number | bigint
+  chainId?: number
   name?: string
   salt?: ResolvedConfig['BytesType']['outputs']
   verifyingContract?: Address


### PR DESCRIPTION
## Description

Changes `TypedDataDomain['chainId']` to `number`

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
