### PR TITLE
feat(human-readable): convert dynamic integer alias types to fixed representations

### DIFF
--- a/.changeset/quick-ears-count.md
+++ b/.changeset/quick-ears-count.md
@@ -1,0 +1,5 @@
+---
+'abitype': patch
+---
+
+Updated human-readable ABI parsing to convert dynamic integer alias types (e.g. `int` and `uint`) to fixed types (e.g. `int256` and `uint256`).

--- a/src/human-readable/__snapshots__/parseAbi.test.ts.snap
+++ b/src/human-readable/__snapshots__/parseAbi.test.ts.snap
@@ -1968,7 +1968,7 @@ exports[`parseAbi 1`] = `
       },
       {
         "name": "amount",
-        "type": "uint",
+        "type": "uint256",
       },
     ],
     "name": "BadReturnValueFromERC20OnTransfer",
@@ -2003,15 +2003,15 @@ exports[`parseAbi 1`] = `
     "inputs": [
       {
         "name": "orderIndex",
-        "type": "uint",
+        "type": "uint256",
       },
       {
         "name": "considerationAmount",
-        "type": "uint",
+        "type": "uint256",
       },
       {
         "name": "shortfallAmount",
-        "type": "uint",
+        "type": "uint256",
       },
     ],
     "name": "ConsiderationNotMet",
@@ -2038,11 +2038,11 @@ exports[`parseAbi 1`] = `
       },
       {
         "name": "identifiers",
-        "type": "uint[]",
+        "type": "uint256[]",
       },
       {
         "name": "amounts",
-        "type": "uint[]",
+        "type": "uint256[]",
       },
     ],
     "name": "ERC1155BatchTransferGenericFailure",
@@ -2306,11 +2306,11 @@ exports[`parseAbi 1`] = `
       },
       {
         "name": "identifier",
-        "type": "uint",
+        "type": "uint256",
       },
       {
         "name": "amount",
-        "type": "uint",
+        "type": "uint256",
       },
     ],
     "name": "TokenTransferGenericFailure",
@@ -2320,11 +2320,11 @@ exports[`parseAbi 1`] = `
     "inputs": [
       {
         "name": "orderIndex",
-        "type": "uint",
+        "type": "uint256",
       },
       {
         "name": "considerationIndex",
-        "type": "uint",
+        "type": "uint256",
       },
     ],
     "name": "UnresolvedConsiderationCriteria",

--- a/src/human-readable/runtime/utils.test.ts
+++ b/src/human-readable/runtime/utils.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest'
 
 import { functionModifiers } from './signatures'
 import {
-  isProtectedSolidityKeyword,
+  isSolidityKeyword,
   isSolidityType,
   parseAbiParameter,
   parseSignature,
@@ -371,6 +371,19 @@ test.each([
   })
 })
 
+test('dynamic integer', () => {
+  expect(parseAbiParameter('int')).toMatchInlineSnapshot(`
+    {
+      "type": "int256",
+    }
+  `)
+  expect(parseAbiParameter('uint')).toMatchInlineSnapshot(`
+    {
+      "type": "uint256",
+    }
+  `)
+})
+
 test('structs', () => {
   expect(
     parseAbiParameter('Foo foo', { structs: { Foo: [{ type: 'string' }] } }),
@@ -548,7 +561,7 @@ test.each([
   'typedef',
   'typeof',
 ])('isInvalidSolidiyName($name)', (name) => {
-  expect(isProtectedSolidityKeyword(name)).toEqual(true)
+  expect(isSolidityKeyword(name)).toEqual(true)
 })
 
 test('Unbalanced Parethesis', () => {

--- a/src/human-readable/runtime/utils.ts
+++ b/src/human-readable/runtime/utils.ts
@@ -145,6 +145,7 @@ const abiParameterWithoutTupleRegex =
   /^(?<type>[a-zA-Z0-9_]+?)(?<array>(?:\[\d*?\])+?)?(?:\s(?<modifier>calldata|indexed|memory|storage{1}))?(?:\s(?<name>[a-zA-Z0-9_]+))?$/
 const abiParameterWithTupleRegex =
   /^\((?<type>.+?)\)(?<array>(?:\[\d*?\])+?)?(?:\s(?<modifier>calldata|indexed|memory|storage{1}))?(?:\s(?<name>[a-zA-Z0-9_]+))?$/
+const dynamicIntegerRegex = /^u?int$/
 
 type ParseOptions = {
   modifiers?: Set<Modifier>
@@ -173,7 +174,7 @@ export function parseAbiParameter(param: string, options?: ParseOptions) {
       details: param,
     })
 
-  if (match.name && isProtectedSolidityKeyword(match.name))
+  if (match.name && isSolidityKeyword(match.name))
     throw new BaseError('Invalid ABI parameter.', {
       details: param,
       metaMessages: [
@@ -199,6 +200,8 @@ export function parseAbiParameter(param: string, options?: ParseOptions) {
   } else if (match.type in structs) {
     type = 'tuple'
     components = { components: structs[match.type] }
+  } else if (dynamicIntegerRegex.test(match.type)) {
+    type = `${match.type}256`
   } else {
     type = match.type
     if (!(options?.type === 'struct') && !isSolidityType(type))
@@ -303,7 +306,7 @@ export function isSolidityType(
 const protectedKeywordsRegex =
   /^(?:after|alias|anonymous|apply|auto|byte|calldata|case|catch|constant|copyof|default|defined|error|event|external|false|final|function|immutable|implements|in|indexed|inline|internal|let|mapping|match|memory|mutable|null|of|override|partial|private|promise|public|pure|reference|relocatable|return|returns|sizeof|static|storage|struct|super|supports|switch|this|true|try|typedef|typeof|var|view|virtual)$/
 
-export function isProtectedSolidityKeyword(name: string) {
+export function isSolidityKeyword(name: string) {
   return (
     name === 'address' ||
     name === 'bool' ||


### PR DESCRIPTION
## Description

Converts dynamic integer alias types (e.g. `int` and `uint`) to fixed types (e.g. `int256` and `uint256`).

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
