### PR TITLE
docs: fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Works great for adding blazing fast [autocomplete](https://twitter.com/awkweb/st
 
 ABIType might be a good option for your project if:
 
-- You want to [typecheck](https://abitype.dev/api/types) your ABIs or EIP-712 Typed Data.
+- You want to [typecheck](https://abitype.dev/api/types.html) your ABIs or EIP-712 Typed Data.
 - You want to add type inference and autocomplete to your library based on user-provided ABIs or EIP-712 Typed Data, like [wagmi](https://wagmi.sh) and [viem](https://viem.sh).
-- You need to [convert ABI types](https://abitype.dev/api/utilities#abiparameterstoprimitivetypes) (e.g. `'string'`) to TypeScript types (e.g. `string`) or other type transformations.
-- You need to validate ABIs at [runtime](https://abitype.dev/api/zod) (e.g. after fetching from external resource).
+- You need to [convert ABI types](https://abitype.dev/api/utilities.html#abiparameterstoprimitivetypes) (e.g. `'string'`) to TypeScript types (e.g. `string`) or other type transformations.
+- You need to validate ABIs at [runtime](https://abitype.dev/api/zod.html) (e.g. after fetching from external resource).
 - You don’t want to set up a build process to generate types (e.g. TypeChain).
 
 ## Install


### PR DESCRIPTION
## Description

The documentation links in the README currently return 404 errors:

![image](https://user-images.githubusercontent.com/29699850/225530991-0dcb9a22-03db-4bfc-8645-6d4f2cb6fafb.png)

The `.html` file extension in the link is required.

## Additional Information

- [X] I read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [X] I added documentation related to the changes made.
- [n/a] I added or updated tests related to the changes made.
