### PR TITLE
feat: add eip165 abi

### DIFF
--- a/.changeset/large-waves-impress.md
+++ b/.changeset/large-waves-impress.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+Added EIP-165 abi, and rename `address` to `zeroAddress`

--- a/docs/api/test.md
+++ b/docs/api/test.md
@@ -27,6 +27,7 @@ import {
   wagmiMintExampleAbi,
   wethAbi,
   writingEditionsFactoryAbi,
+  eip165Abi,
 } from 'abitype/test'
 ```
 

--- a/examples/readContract.test-d.ts
+++ b/examples/readContract.test-d.ts
@@ -1,10 +1,10 @@
 import type { Abi, Address, ResolvedConfig } from 'abitype'
 import { parseAbi } from 'abitype'
 import {
-  address,
   wagmiMintExampleAbi,
   wagmiMintExampleHumanReadableAbi,
   writingEditionsFactoryAbi,
+  zeroAddress,
 } from 'abitype/test'
 import { assertType, test } from 'vitest'
 
@@ -14,7 +14,7 @@ test('readContract', () => {
   test('args', () => {
     test('zero', () => {
       const result = readContract({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         functionName: 'name',
       })
@@ -23,7 +23,7 @@ test('readContract', () => {
 
     test('one', () => {
       const result = readContract({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         functionName: 'tokenURI',
         args: [123n],
@@ -33,10 +33,10 @@ test('readContract', () => {
 
     test('two or more', () => {
       const result = readContract({
-        address,
+        address: zeroAddress,
         abi: writingEditionsFactoryAbi,
         functionName: 'predictDeterministicAddress',
-        args: [address, '0xfoo'],
+        args: [zeroAddress, '0xfoo'],
       })
       assertType<Address>(result)
     })
@@ -45,7 +45,7 @@ test('readContract', () => {
   test('return types', () => {
     test('string', () => {
       const result = readContract({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         functionName: 'name',
       })
@@ -54,7 +54,7 @@ test('readContract', () => {
 
     test('Address', () => {
       const result = readContract({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         functionName: 'ownerOf',
         args: [123n],
@@ -64,10 +64,10 @@ test('readContract', () => {
 
     test('number', () => {
       const result = readContract({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         functionName: 'balanceOf',
-        args: [address],
+        args: [zeroAddress],
       })
       assertType<ResolvedConfig['BigIntType']>(result)
     })
@@ -76,7 +76,7 @@ test('readContract', () => {
   test('behavior', () => {
     test('write function not allowed', () => {
       const result = readContract({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         // @ts-expect-error Trying to use non-read function
         functionName: 'approve',
@@ -102,15 +102,15 @@ test('readContract', () => {
         },
       ]
       const result1 = readContract({
-        address,
+        address: zeroAddress,
         abi: abi,
         functionName: 'foo',
       })
       const result2 = readContract({
-        address,
+        address: zeroAddress,
         abi: abi,
         functionName: 'bar',
-        args: [address],
+        args: [zeroAddress],
       })
       type Result1 = typeof result1
       type Result2 = typeof result2
@@ -136,15 +136,15 @@ test('readContract', () => {
         },
       ]
       const result1 = readContract({
-        address,
+        address: zeroAddress,
         abi: abi,
         functionName: 'foo',
       })
       const result2 = readContract({
-        address,
+        address: zeroAddress,
         abi: abi,
         functionName: 'bar',
-        args: [address],
+        args: [zeroAddress],
       })
       type Result1 = typeof result1
       type Result2 = typeof result2
@@ -154,7 +154,7 @@ test('readContract', () => {
 
     test('defined inline', () => {
       const result1 = readContract({
-        address,
+        address: zeroAddress,
         abi: [
           {
             name: 'foo',
@@ -174,7 +174,7 @@ test('readContract', () => {
         functionName: 'foo',
       })
       const result2 = readContract({
-        address,
+        address: zeroAddress,
         abi: [
           {
             name: 'foo',
@@ -192,7 +192,7 @@ test('readContract', () => {
           },
         ],
         functionName: 'bar',
-        args: [address],
+        args: [zeroAddress],
       })
       type Result1 = typeof result1
       type Result2 = typeof result2
@@ -202,10 +202,10 @@ test('readContract', () => {
 
     test('human readable', () => {
       const result = readContract({
-        address,
+        address: zeroAddress,
         abi: parseAbi(wagmiMintExampleHumanReadableAbi),
         functionName: 'balanceOf',
-        args: [address],
+        args: [zeroAddress],
       })
       assertType<bigint>(result)
     })

--- a/examples/readContracts.test-d.ts
+++ b/examples/readContracts.test-d.ts
@@ -1,10 +1,10 @@
 import type { ResolvedConfig } from 'abitype'
 import {
-  address,
   nestedTupleArrayAbi,
   nounsAuctionHouseAbi,
   wagmiMintExampleAbi,
   writingEditionsFactoryAbi,
+  zeroAddress,
 } from 'abitype/test'
 import { assertType, test } from 'vitest'
 
@@ -16,12 +16,12 @@ test('readContracts', () => {
       const result = readContracts({
         contracts: [
           {
-            address,
+            address: zeroAddress,
             abi: wagmiMintExampleAbi,
             functionName: 'name',
           },
           {
-            address,
+            address: zeroAddress,
             abi: nounsAuctionHouseAbi,
             functionName: 'auction',
           },
@@ -53,13 +53,13 @@ test('readContracts', () => {
       const result = readContracts({
         contracts: [
           {
-            address,
+            address: zeroAddress,
             abi: wagmiMintExampleAbi,
             functionName: 'balanceOf',
-            args: [address],
+            args: [zeroAddress],
           },
           {
-            address,
+            address: zeroAddress,
             abi: wagmiMintExampleAbi,
             functionName: 'ownerOf',
             args: [123n],
@@ -75,7 +75,7 @@ test('readContracts', () => {
       const result = readContracts({
         contracts: [
           {
-            address,
+            address: zeroAddress,
             abi: wagmiMintExampleAbi,
             functionName: 'supportsInterface',
             args: ['0xfoobar'],
@@ -90,7 +90,7 @@ test('readContracts', () => {
       const result = readContracts({
         contracts: [
           {
-            address,
+            address: zeroAddress,
             abi: nestedTupleArrayAbi,
             functionName: 'v',
             args: [
@@ -103,11 +103,11 @@ test('readContracts', () => {
             ],
           },
           {
-            address,
+            address: zeroAddress,
             abi: writingEditionsFactoryAbi,
             functionName: 'getSalt',
             args: [
-              address,
+              zeroAddress,
               {
                 name: 'Test',
                 symbol: '$TEST',
@@ -116,8 +116,8 @@ test('readContracts', () => {
                 contentURI: 'arweave://digest',
                 price: 0.1,
                 limit: 100n,
-                fundingRecipient: address,
-                renderer: address,
+                fundingRecipient: zeroAddress,
+                renderer: zeroAddress,
                 nonce: 123n,
                 fee: 0,
               },
@@ -134,7 +134,7 @@ test('readContracts', () => {
       const result = readContracts({
         contracts: [
           {
-            address,
+            address: zeroAddress,
             abi: wagmiMintExampleAbi,
             // @ts-expect-error Trying to use non-read function
             functionName: 'approve',
@@ -148,19 +148,19 @@ test('readContracts', () => {
       const result = readContracts({
         contracts: [
           {
-            address,
+            address: zeroAddress,
             abi: wagmiMintExampleAbi,
             functionName: 'tokenURI',
             args: [1n],
           },
           {
-            address,
+            address: zeroAddress,
             abi: writingEditionsFactoryAbi,
             functionName: 'predictDeterministicAddress',
-            args: [address, address],
+            args: [zeroAddress, zeroAddress],
           },
           {
-            address,
+            address: zeroAddress,
             abi: [
               {
                 type: 'function',
@@ -175,7 +175,7 @@ test('readContracts', () => {
               },
             ],
             functionName: 'balanceOf',
-            args: [[address], [address], 1n],
+            args: [[zeroAddress], [zeroAddress], 1n],
           },
         ],
       })
@@ -190,13 +190,13 @@ test('readContracts', () => {
     test('without const assertion', () => {
       const contracts = [
         {
-          address,
+          address: zeroAddress,
           abi: wagmiMintExampleAbi,
           functionName: 'tokenURI',
           args: [1n],
         },
         {
-          address,
+          address: zeroAddress,
           abi: wagmiMintExampleAbi,
           functionName: 'balanceOf',
           args: ['0x…'],

--- a/examples/useContractRead.test-d.ts
+++ b/examples/useContractRead.test-d.ts
@@ -1,8 +1,8 @@
 import type { Abi, Address, ResolvedConfig } from 'abitype'
 import {
-  address,
   wagmiMintExampleAbi,
   writingEditionsFactoryAbi,
+  zeroAddress,
 } from 'abitype/test'
 import { assertType, test } from 'vitest'
 
@@ -12,7 +12,7 @@ test('useContractRead', () => {
   test('args', () => {
     test('zero', () => {
       const result = useContractRead({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         functionName: 'name',
         // ^?
@@ -22,7 +22,7 @@ test('useContractRead', () => {
 
     test('one', () => {
       const result = useContractRead({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         functionName: 'tokenURI',
         args: [123n],
@@ -32,10 +32,10 @@ test('useContractRead', () => {
 
     test('two or more', () => {
       const result = useContractRead({
-        address,
+        address: zeroAddress,
         abi: writingEditionsFactoryAbi,
         functionName: 'predictDeterministicAddress',
-        args: [address, '0xfoo'],
+        args: [zeroAddress, '0xfoo'],
       })
       assertType<{ data: Address }>(result)
     })
@@ -44,7 +44,7 @@ test('useContractRead', () => {
   test('return types', () => {
     test('string', () => {
       const result = useContractRead({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         functionName: 'name',
       })
@@ -53,7 +53,7 @@ test('useContractRead', () => {
 
     test('Address', () => {
       const result = useContractRead({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         functionName: 'ownerOf',
         args: [123n],
@@ -63,10 +63,10 @@ test('useContractRead', () => {
 
     test('number', () => {
       const result = useContractRead({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         functionName: 'balanceOf',
-        args: [address],
+        args: [zeroAddress],
       })
       assertType<{ data: ResolvedConfig['BigIntType'] }>(result)
     })
@@ -75,7 +75,7 @@ test('useContractRead', () => {
   test('behavior', () => {
     test('write function not allowed', () => {
       const result = useContractRead({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         // @ts-expect-error Trying to use non-read function
         functionName: 'approve',
@@ -101,15 +101,15 @@ test('useContractRead', () => {
         },
       ]
       const result1 = useContractRead({
-        address,
+        address: zeroAddress,
         abi: abi,
         functionName: 'foo',
       })
       const result2 = useContractRead({
-        address,
+        address: zeroAddress,
         abi: abi,
         functionName: 'bar',
-        args: [address],
+        args: [zeroAddress],
       })
       type Result1 = typeof result1
       type Result2 = typeof result2
@@ -135,15 +135,15 @@ test('useContractRead', () => {
         },
       ]
       const result1 = useContractRead({
-        address,
+        address: zeroAddress,
         abi: abi,
         functionName: 'foo',
       })
       const result2 = useContractRead({
-        address,
+        address: zeroAddress,
         abi: abi,
         functionName: 'bar',
-        args: [address],
+        args: [zeroAddress],
       })
       type Result1 = typeof result1
       type Result2 = typeof result2
@@ -153,7 +153,7 @@ test('useContractRead', () => {
 
     test('defined inline', () => {
       const result1 = useContractRead({
-        address,
+        address: zeroAddress,
         abi: [
           {
             name: 'foo',
@@ -173,7 +173,7 @@ test('useContractRead', () => {
         functionName: 'foo',
       })
       const result2 = useContractRead({
-        address,
+        address: zeroAddress,
         abi: [
           {
             name: 'foo',
@@ -191,7 +191,7 @@ test('useContractRead', () => {
           },
         ],
         functionName: 'bar',
-        args: [address],
+        args: [zeroAddress],
       })
       type Result1 = typeof result1
       type Result2 = typeof result2
@@ -205,7 +205,7 @@ test('useWagmiMintExampleRead', () => {
   test('args', () => {
     test('zero', () => {
       const result = useWagmiMintExampleRead({
-        address,
+        address: zeroAddress,
         functionName: 'name',
         // ^?
       })
@@ -214,7 +214,7 @@ test('useWagmiMintExampleRead', () => {
 
     test('one', () => {
       const result = useWagmiMintExampleRead({
-        address,
+        address: zeroAddress,
         functionName: 'balanceOf',
         args: ['0x…'],
       })

--- a/examples/useContractReads.test-d.ts
+++ b/examples/useContractReads.test-d.ts
@@ -1,10 +1,10 @@
 import type { ResolvedConfig } from 'abitype'
 import {
-  address,
   nestedTupleArrayAbi,
   nounsAuctionHouseAbi,
   wagmiMintExampleAbi,
   writingEditionsFactoryAbi,
+  zeroAddress,
 } from 'abitype/test'
 import { assertType, test } from 'vitest'
 
@@ -16,12 +16,12 @@ test('useContractReads', () => {
       const result = useContractReads({
         contracts: [
           {
-            address,
+            address: zeroAddress,
             abi: wagmiMintExampleAbi,
             functionName: 'name',
           },
           {
-            address,
+            address: zeroAddress,
             abi: nounsAuctionHouseAbi,
             functionName: 'auction',
           },
@@ -53,13 +53,13 @@ test('useContractReads', () => {
       const result = useContractReads({
         contracts: [
           {
-            address,
+            address: zeroAddress,
             abi: wagmiMintExampleAbi,
             functionName: 'balanceOf',
-            args: [address],
+            args: [zeroAddress],
           },
           {
-            address,
+            address: zeroAddress,
             abi: wagmiMintExampleAbi,
             functionName: 'ownerOf',
             args: [123n],
@@ -75,7 +75,7 @@ test('useContractReads', () => {
       const result = useContractReads({
         contracts: [
           {
-            address,
+            address: zeroAddress,
             abi: nestedTupleArrayAbi,
             functionName: 'v',
             args: [
@@ -88,11 +88,11 @@ test('useContractReads', () => {
             ],
           },
           {
-            address,
+            address: zeroAddress,
             abi: writingEditionsFactoryAbi,
             functionName: 'getSalt',
             args: [
-              address,
+              zeroAddress,
               {
                 name: 'Test',
                 symbol: '$TEST',
@@ -101,8 +101,8 @@ test('useContractReads', () => {
                 contentURI: 'arweave://digest',
                 price: 0.1,
                 limit: 100n,
-                fundingRecipient: address,
-                renderer: address,
+                fundingRecipient: zeroAddress,
+                renderer: zeroAddress,
                 nonce: 123n,
                 fee: 0,
               },
@@ -121,7 +121,7 @@ test('useContractReads', () => {
       const result = useContractReads({
         contracts: [
           {
-            address,
+            address: zeroAddress,
             abi: wagmiMintExampleAbi,
             // @ts-expect-error Trying to use non-read function
             functionName: 'approve',
@@ -135,19 +135,19 @@ test('useContractReads', () => {
       const result = useContractReads({
         contracts: [
           {
-            address,
+            address: zeroAddress,
             abi: wagmiMintExampleAbi,
             functionName: 'tokenURI',
             args: [1n],
           },
           {
-            address,
+            address: zeroAddress,
             abi: writingEditionsFactoryAbi,
             functionName: 'predictDeterministicAddress',
-            args: [address, address],
+            args: [zeroAddress, zeroAddress],
           },
           {
-            address,
+            address: zeroAddress,
             abi: [
               {
                 type: 'function',
@@ -162,7 +162,7 @@ test('useContractReads', () => {
               },
             ],
             functionName: 'balanceOf',
-            args: [[address], [address], 1n],
+            args: [[zeroAddress], [zeroAddress], 1n],
           },
         ],
       })
@@ -177,13 +177,13 @@ test('useContractReads', () => {
     test('without const assertion', () => {
       const contracts = [
         {
-          address,
+          address: zeroAddress,
           abi: wagmiMintExampleAbi,
           functionName: 'tokenURI',
           args: [1n],
         },
         {
-          address,
+          address: zeroAddress,
           abi: wagmiMintExampleAbi,
           functionName: 'balanceOf',
           args: ['0x…'],

--- a/examples/watchContractEvent.test-d.ts
+++ b/examples/watchContractEvent.test-d.ts
@@ -1,8 +1,8 @@
 import type { Abi, ResolvedConfig } from 'abitype'
 import {
-  address,
   wagmiMintExampleAbi,
   writingEditionsFactoryAbi,
+  zeroAddress,
 } from 'abitype/test'
 import { assertType, test } from 'vitest'
 
@@ -12,7 +12,7 @@ test('watchContractEvent', () => {
   test('args', () => {
     test('zero', () => {
       watchContractEvent({
-        address,
+        address: zeroAddress,
         abi: [
           {
             name: 'Foo',
@@ -36,7 +36,7 @@ test('watchContractEvent', () => {
 
     test('one', () => {
       watchContractEvent({
-        address,
+        address: zeroAddress,
         abi: writingEditionsFactoryAbi,
         eventName: 'FactoryGuardSet',
         listener(guard) {
@@ -47,7 +47,7 @@ test('watchContractEvent', () => {
 
     test('two or more', () => {
       watchContractEvent({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         eventName: 'Transfer',
         listener(from, to, tokenId) {
@@ -76,7 +76,7 @@ test('watchContractEvent', () => {
         },
       ]
       watchContractEvent({
-        address,
+        address: zeroAddress,
         abi,
         eventName: 'Foo',
         listener(name) {
@@ -101,7 +101,7 @@ test('watchContractEvent', () => {
         },
       ]
       watchContractEvent({
-        address,
+        address: zeroAddress,
         abi,
         eventName: 'Foo',
         listener(name) {
@@ -112,7 +112,7 @@ test('watchContractEvent', () => {
 
     test('defined inline', () => {
       watchContractEvent({
-        address,
+        address: zeroAddress,
         abi: [
           {
             name: 'Foo',

--- a/examples/writeContract.test-d.ts
+++ b/examples/writeContract.test-d.ts
@@ -1,13 +1,13 @@
 import type { Abi, ResolvedConfig } from 'abitype'
 import { parseAbi } from 'abitype'
 import {
-  address,
   ensRegistryWithFallbackAbi,
   nestedTupleArrayAbi,
   nounsAuctionHouseAbi,
   wagmiMintExampleAbi,
   wagmiMintExampleHumanReadableAbi,
   writingEditionsFactoryAbi,
+  zeroAddress,
 } from 'abitype/test'
 import { assertType, test } from 'vitest'
 
@@ -17,7 +17,7 @@ test('writeContract', () => {
   test('args', () => {
     test('zero', () => {
       const result = writeContract({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         functionName: 'mint',
       })
@@ -26,7 +26,7 @@ test('writeContract', () => {
 
     test('one', () => {
       const result = writeContract({
-        address,
+        address: zeroAddress,
         abi: nounsAuctionHouseAbi,
         functionName: 'createBid',
         args: [123n],
@@ -36,16 +36,16 @@ test('writeContract', () => {
 
     test('two or more', () => {
       const result1 = writeContract({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         functionName: 'approve',
-        args: [address, 123n],
+        args: [zeroAddress, 123n],
       })
       const result2 = writeContract({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         functionName: 'transferFrom',
-        args: [address, address, 123n],
+        args: [zeroAddress, zeroAddress, 123n],
       })
       assertType<void>(result1)
       assertType<void>(result2)
@@ -53,7 +53,7 @@ test('writeContract', () => {
 
     test('tuple', () => {
       const result = writeContract({
-        address,
+        address: zeroAddress,
         abi: writingEditionsFactoryAbi,
         functionName: 'create',
         args: [
@@ -65,8 +65,8 @@ test('writeContract', () => {
             contentURI: 'arweave://digest',
             price: 0.1,
             limit: 100n,
-            fundingRecipient: address,
-            renderer: address,
+            fundingRecipient: zeroAddress,
+            renderer: zeroAddress,
             nonce: 123n,
             fee: 0,
           },
@@ -79,7 +79,7 @@ test('writeContract', () => {
   test('return types', () => {
     test('void', () => {
       const result = writeContract({
-        address,
+        address: zeroAddress,
         abi: nounsAuctionHouseAbi,
         functionName: 'pause',
       })
@@ -88,10 +88,10 @@ test('writeContract', () => {
 
     test('bytes32', () => {
       const result = writeContract({
-        address,
+        address: zeroAddress,
         abi: ensRegistryWithFallbackAbi,
         functionName: 'setSubnodeOwner',
-        args: ['0xfoo', '0xbar', address],
+        args: ['0xfoo', '0xbar', zeroAddress],
       })
       assertType<ResolvedConfig['BytesType']['outputs']>(result)
     })
@@ -122,7 +122,7 @@ test('writeContract', () => {
         fundingRecipient: ResolvedConfig['AddressType']
       }
       const result = writeContract({
-        address,
+        address: zeroAddress,
         abi,
         functionName: 'foo',
       })
@@ -131,7 +131,7 @@ test('writeContract', () => {
 
     test('tuple[]', () => {
       const result = writeContract({
-        address,
+        address: zeroAddress,
         abi: nestedTupleArrayAbi,
         functionName: 'f',
         args: [{ a: 1, b: [2], c: [{ x: 1, y: 1 }] }, { x: 1n, y: 1n }, 1n],
@@ -148,7 +148,7 @@ test('writeContract', () => {
   test('behavior', () => {
     test('read function not allowed', () => {
       const result = writeContract({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         // @ts-expect-error Trying to use read function
         functionName: 'symbol',
@@ -158,18 +158,18 @@ test('writeContract', () => {
 
     test('function with overloads', () => {
       const result1 = writeContract({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         functionName: 'safeTransferFrom',
-        args: [address, address, 123n],
+        args: [zeroAddress, zeroAddress, 123n],
       })
       assertType<void>(result1)
 
       const result2 = writeContract({
-        address,
+        address: zeroAddress,
         abi: wagmiMintExampleAbi,
         functionName: 'safeTransferFrom',
-        args: [address, address, 123n, '0xfoo'],
+        args: [zeroAddress, zeroAddress, 123n, '0xfoo'],
       })
       assertType<void>(result2)
     })
@@ -185,7 +185,7 @@ test('writeContract', () => {
         },
       ]
       const result = writeContract({
-        address,
+        address: zeroAddress,
         abi,
         functionName: 'foo',
         args: ['bar'],
@@ -204,7 +204,7 @@ test('writeContract', () => {
         },
       ]
       const result = writeContract({
-        address,
+        address: zeroAddress,
         abi,
         functionName: 'foo',
         args: ['bar'],
@@ -214,7 +214,7 @@ test('writeContract', () => {
 
     test('defined inline', () => {
       const result = writeContract({
-        address,
+        address: zeroAddress,
         abi: [
           {
             name: 'foo',
@@ -232,10 +232,10 @@ test('writeContract', () => {
 
     test('human readable', () => {
       const result = writeContract({
-        address,
+        address: zeroAddress,
         abi: parseAbi(wagmiMintExampleHumanReadableAbi),
         functionName: 'safeTransferFrom',
-        args: [address, address, 123n],
+        args: [zeroAddress, zeroAddress, 123n],
       })
       assertType<void>(result)
     })

--- a/src/test/abis.ts
+++ b/src/test/abis.ts
@@ -3503,3 +3503,29 @@ export const writingEditionsFactoryAbi = [
     type: 'function',
   },
 ] as const
+
+/**
+ * EIP-165
+ * https://eips.ethereum.org/EIPS/eip-165
+ */
+export const eip165Abi = [
+  {
+    inputs: [
+      {
+        internalType: 'bytes4',
+        name: 'interfaceId',
+        type: 'bytes4',
+      },
+    ],
+    name: 'supportsInterface',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const

--- a/src/test/human-readable.ts
+++ b/src/test/human-readable.ts
@@ -303,3 +303,7 @@ export const writingEditionsFactoryHumanReadableAbi = [
   'function transferOwnership(address nextOwner_)',
   'function treasuryConfiguration() view returns (address)',
 ] as const
+
+export const eip165HumanReadableAbi = [
+  'function supportsInterface(bytes4 interfaceId) view returns (bool)',
+]

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -16,6 +16,7 @@ it('should expose correct exports', () => {
       "wagmiMintExampleAbi",
       "wethAbi",
       "writingEditionsFactoryAbi",
+      "eip165Abi",
       "customSolidityErrorsHumanReadableAbi",
       "ensHumanReadableAbi",
       "ensRegistryWithFallbackHumanReadableAbi",
@@ -26,6 +27,7 @@ it('should expose correct exports', () => {
       "wagmiMintExampleHumanReadableAbi",
       "wethHumanReadableAbi",
       "writingEditionsFactoryHumanReadableAbi",
+      "eip165HumanReadableAbi",
     ]
   `)
 })

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -5,7 +5,7 @@ import * as Exports from './'
 it('should expose correct exports', () => {
   expect(Object.keys(Exports)).toMatchInlineSnapshot(`
     [
-      "address",
+      "zeroAddress",
       "customSolidityErrorsAbi",
       "ensAbi",
       "ensRegistryWithFallbackAbi",

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,4 +1,4 @@
-export const address = '0x0000000000000000000000000000000000000000' as const
+export const zeroAddress = '0x0000000000000000000000000000000000000000' as const
 
 export {
   customSolidityErrorsAbi,

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -11,6 +11,7 @@ export {
   wagmiMintExampleAbi,
   wethAbi,
   writingEditionsFactoryAbi,
+  eip165Abi,
 } from './abis'
 
 export {
@@ -24,4 +25,5 @@ export {
   wagmiMintExampleHumanReadableAbi,
   wethHumanReadableAbi,
   writingEditionsFactoryHumanReadableAbi,
+  eip165HumanReadableAbi,
 } from './human-readable'

--- a/src/utils.test-d.ts
+++ b/src/utils.test-d.ts
@@ -1,7 +1,7 @@
 import { assertType, test } from 'vitest'
 
 import type { Abi } from './abi'
-import { address } from './test'
+import { zeroAddress } from './test'
 import type {
   customSolidityErrorsAbi,
   ensRegistryWithFallbackAbi,
@@ -31,7 +31,7 @@ import type {
 
 test('AbiTypeToPrimitiveType', () => {
   test('address', () => {
-    assertType<AbiTypeToPrimitiveType<'address'>>(address)
+    assertType<AbiTypeToPrimitiveType<'address'>>(zeroAddress)
   })
 
   test('bool', () => {
@@ -48,7 +48,7 @@ test('AbiTypeToPrimitiveType', () => {
   })
 
   test('function', () => {
-    assertType<AbiTypeToPrimitiveType<'function'>>(`${address}foo`)
+    assertType<AbiTypeToPrimitiveType<'function'>>(`${zeroAddress}foo`)
   })
 
   test('string', () => {
@@ -97,7 +97,7 @@ test('AbiParameterToPrimitiveType', () => {
       name: 'owner'
       type: 'address'
     }>
-    assertType<Result>(address)
+    assertType<Result>(zeroAddress)
     // @ts-expect-error missing "0x" prefix
     assertType<Result>('foo')
   })
@@ -120,7 +120,7 @@ test('AbiParameterToPrimitiveType', () => {
     type FunctionResult = AbiParameterToPrimitiveType<{
       type: 'function'
     }>
-    assertType<FunctionResult>(`${address}foo`)
+    assertType<FunctionResult>(`${zeroAddress}foo`)
   })
 
   test('string', () => {
@@ -128,7 +128,7 @@ test('AbiParameterToPrimitiveType', () => {
       type: 'string'
     }>
     assertType<Result>('foo')
-    assertType<Result>(address)
+    assertType<Result>(zeroAddress)
   })
 
   test('tuple', () => {
@@ -161,8 +161,8 @@ test('AbiParameterToPrimitiveType', () => {
       contentURI: 'arweave://digest',
       price: 1n,
       limit: 100n,
-      fundingRecipient: address,
-      renderer: address,
+      fundingRecipient: zeroAddress,
+      renderer: zeroAddress,
       nonce: 123n,
       fee: 0,
     })
@@ -182,8 +182,8 @@ test('AbiParameterToPrimitiveType', () => {
       // @ts-expect-error invalid value
       price: '0.1',
       limit: 100n,
-      fundingRecipient: address,
-      renderer: address,
+      fundingRecipient: zeroAddress,
+      renderer: zeroAddress,
       nonce: 123n,
       fee: 0,
     })
@@ -242,8 +242,8 @@ test('AbiParameterToPrimitiveType', () => {
       'arweave://digest',
       1n,
       100n,
-      address,
-      address,
+      zeroAddress,
+      zeroAddress,
       123n,
       0,
     ])
@@ -447,7 +447,7 @@ test('AbiParametersToPrimitiveTypes', () => {
         { name: 'trait'; type: 'string[]' },
       ]
     >
-    assertType<Result>([address, 1n, ['foo']])
+    assertType<Result>([zeroAddress, 1n, ['foo']])
   })
 
   test('deeply nested parameters', () => {


### PR DESCRIPTION
## Description

What changes are made in this PR? Is it a feature or a bug fix?

## Additional Information

- [x] I read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [x] I added documentation related to the changes made.
- [x] I added or updated tests related to the changes made.

Your ENS/address: izayl.eth

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for EIP-165 to the abitype library, along with other minor changes and improvements.

### Detailed summary
- Added EIP-165 abi to `src/test/abis.ts` and `src/test/human-readable.ts`
- Renamed `address` export to `zeroAddress` in `src/test/index.ts`, `examples/watchContractEvent.test-d.ts`, `examples/useContractReads.test-d.ts`, and `examples/readContracts.test-d.ts`
- Updated imports in `src/utils.test-d.ts` and `examples/readContract.test-d.ts` to use `zeroAddress` instead of `address`

> The following files were skipped due to too many changes: `examples/readContract.test-d.ts`, `examples/useContractRead.test-d.ts`, `examples/writeContract.test-d.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->