### PR TITLE
feat: support no-space returns

### DIFF
--- a/.changeset/young-deers-appear.md
+++ b/.changeset/young-deers-appear.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+support no-space returns

--- a/src/human-readable/runtime/signatures.test.ts
+++ b/src/human-readable/runtime/signatures.test.ts
@@ -65,6 +65,12 @@ test('isFunctionSignature', () => {
   expect(isFunctionSignature('function name(string)')).toMatchInlineSnapshot(
     'true',
   )
+  expect(
+    isFunctionSignature('function name(string) returns (uint256)'),
+  ).toMatchInlineSnapshot('true')
+  expect(
+    isFunctionSignature('function name(string) returns(uint256)'),
+  ).toMatchInlineSnapshot('true')
   expect(isFunctionSignature('struct Name { string; }')).toMatchInlineSnapshot(
     'false',
   )
@@ -78,6 +84,28 @@ test('execFunctionSignature', () => {
       "returns": undefined,
       "scope": undefined,
       "stateMutability": undefined,
+    }
+  `)
+  expect(
+    execFunctionSignature('function foo() view returns (uint256)'),
+  ).toMatchInlineSnapshot(`
+    {
+      "name": "foo",
+      "parameters": "",
+      "returns": "uint256",
+      "scope": undefined,
+      "stateMutability": "view",
+    }
+  `)
+  expect(
+    execFunctionSignature('function foo() view returns(uint256)'),
+  ).toMatchInlineSnapshot(`
+    {
+      "name": "foo",
+      "parameters": "",
+      "returns": "uint256",
+      "scope": undefined,
+      "stateMutability": "view",
     }
   `)
   expect(

--- a/src/human-readable/runtime/signatures.ts
+++ b/src/human-readable/runtime/signatures.ts
@@ -34,7 +34,7 @@ export function execEventSignature(signature: string) {
 
 // https://regexr.com/78u1b
 const functionSignatureRegex =
-  /^function (?<name>[a-zA-Z0-9_]+)\((?<parameters>.*?)\)(?: (?<scope>external|public{1}))?(?: (?<stateMutability>pure|view|nonpayable|payable{1}))?(?: returns \((?<returns>.*?)\))?$/
+  /^function (?<name>[a-zA-Z0-9_]+)\((?<parameters>.*?)\)(?: (?<scope>external|public{1}))?(?: (?<stateMutability>pure|view|nonpayable|payable{1}))?(?: returns\s?\((?<returns>.*?)\))?$/
 export function isFunctionSignature(signature: string) {
   return functionSignatureRegex.test(signature)
 }

--- a/src/human-readable/types/signatures-test-d.ts
+++ b/src/human-readable/types/signatures-test-d.ts
@@ -51,17 +51,25 @@ test('IsFunctionSignature', () => {
   // basic
   assertType<IsFunctionSignature<'function foo()'>>(true)
   assertType<IsFunctionSignature<'function foo() returns (uint256)'>>(true)
+  assertType<IsFunctionSignature<'function foo() returns(uint256)'>>(true)
   assertType<IsFunctionSignature<'function foo() view'>>(true)
   assertType<IsFunctionSignature<'function foo() public'>>(true)
   // combinations
   assertType<IsFunctionSignature<'function foo() view returns (uint256)'>>(true)
+  assertType<IsFunctionSignature<'function foo() view returns(uint256)'>>(true)
   assertType<IsFunctionSignature<'function foo() public view'>>(true)
   assertType<
     IsFunctionSignature<'function foo() public view returns (uint256)'>
   >(true)
+  assertType<
+    IsFunctionSignature<'function foo() public view returns(uint256)'>
+  >(true)
   // params
   assertType<IsFunctionSignature<'function foo(uint256, uint256)'>>(true)
   assertType<IsFunctionSignature<'function foo(uint256) returns (uint256)'>>(
+    true,
+  )
+  assertType<IsFunctionSignature<'function foo(uint256) returns(uint256)'>>(
     true,
   )
   assertType<IsFunctionSignature<'function foo(uint256) view'>>(true)
@@ -69,15 +77,27 @@ test('IsFunctionSignature', () => {
   assertType<
     IsFunctionSignature<'function foo(uint256) view returns (uint256)'>
   >(true)
+  assertType<
+    IsFunctionSignature<'function foo(uint256) view returns(uint256)'>
+  >(true)
   assertType<IsFunctionSignature<'function foo(uint256) public view'>>(true)
   assertType<
     IsFunctionSignature<'function foo(uint256) public view returns (uint256)'>
   >(true)
   assertType<
+    IsFunctionSignature<'function foo(uint256) public view returns(uint256)'>
+  >(true)
+  assertType<
     IsFunctionSignature<'function foo(uint256) public view returns (uint256 tokenId)'>
   >(true)
   assertType<
+    IsFunctionSignature<'function foo(uint256) public view returns(uint256 tokenId)'>
+  >(true)
+  assertType<
     IsFunctionSignature<'function foo(uint256) public view returns (uint256 tokenId, uint256 balance)'>
+  >(true)
+  assertType<
+    IsFunctionSignature<'function foo(uint256) public view returns(uint256 tokenId, uint256 balance)'>
   >(true)
 
   // invalid

--- a/src/human-readable/types/signatures.ts
+++ b/src/human-readable/types/signatures.ts
@@ -37,7 +37,7 @@ export type IsFunctionSignature<T> = T extends FunctionSignature<infer Name>
     : false
   : false
 export type Scope = 'public' | 'external' // `internal` or `private` functions wouldn't make it to ABI so can ignore
-type Returns = `returns (${string})`
+type Returns = `returns (${string})` | `returns(${string})`
 // Almost all valid function signatures, except `function ${string}(${infer Parameters})` since `Parameters` can absorb returns
 type ValidFunctionSignatures =
   | `function ${string}()`


### PR DESCRIPTION
## Description

What changes are made in this PR? Is it a feature or a bug fix?

<img width="1062" alt="image" src="https://user-images.githubusercontent.com/10740043/236675899-3b5f6eb1-68cb-4e0a-95e1-5279a0be7f83.png">

`returns` with no space is a valid syntax in solidity, but current version abitype not allowed, as the case ahead, if the function signature is very long, is hard to known where is the wrong part of signature, so, I think it is good to support it natively in abitype as it is valid syntax in solidity.

## Additional Information

- [x] I read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [ ] I added documentation related to the changes made.
- [x] I added or updated tests related to the changes made.

Your ENS/address: izayl.eth

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for no-space returns and improves the regex for function signatures. 

### Detailed summary
- Added support for no-space returns
- Improved regex for function signatures to handle no-space returns

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->