### PR TITLE
fix: readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 Strict TypeScript types for Ethereum ABIs. ABIType provides utilities and type definitions for ABI properties and values, covering the [Contract ABI Specification](https://docs.soliditylang.org/en/latest/abi-spec.html), as well as [EIP-712](https://eips.ethereum.org/EIPS/eip-712) Typed Data.
 
 ```ts
-import { ExtractAbiFunctions } from 'abitype'
+import type { ExtractAbiFunctions, ExtractAbiFunctionNames } from 'abitype'
 import { erc20Abi } from 'abitype/test'
 
 type FunctionNames = ExtractAbiFunctionNames<typeof erc20Abi, 'view'>

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 Strict TypeScript types for Ethereum ABIs. ABIType provides utilities and type definitions for ABI properties and values, covering the [Contract ABI Specification](https://docs.soliditylang.org/en/latest/abi-spec.html), as well as [EIP-712](https://eips.ethereum.org/EIPS/eip-712) Typed Data.
 
 ```ts
-import type { ExtractAbiFunctions, ExtractAbiFunctionNames } from 'abitype'
+import type { AbiParametersToPrimitiveTypes, ExtractAbiFunctions, ExtractAbiFunctionNames } from 'abitype'
 import { erc20Abi } from 'abitype/test'
 
 type FunctionNames = ExtractAbiFunctionNames<typeof erc20Abi, 'view'>


### PR DESCRIPTION
## Description

Typo identified [here](https://github.com/wagmi-dev/abitype/discussions/140#discussioncomment-5955696)

## Additional Information

- [x] I read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [ ] I added documentation related to the changes made.
- [x] I added or updated tests related to the changes made.

Your ENS/address:

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new imported types and uses them to declare a new type alias in README.md.

### Detailed summary
- Adds `AbiParametersToPrimitiveTypes`, `ExtractAbiFunctionNames` to the imported types.
- Declares a new type alias `FunctionNames` using `ExtractAbiFunctionNames` and `typeof erc20Abi`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->