### PR TITLE
fix: package.json exports zod entrypoint path

### DIFF
--- a/.changeset/tricky-foxes-end.md
+++ b/.changeset/tricky-foxes-end.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+Fixed package.json Zod entrypoint ESM path.

--- a/package.json
+++ b/package.json
@@ -63,22 +63,16 @@
     },
     "./zod": {
       "types": "./dist/types/zod/index.d.ts",
-      "import": "./dist/esm/zod/index.mts",
+      "import": "./dist/esm/zod/index.js",
       "require": "./dist/cjs/zod/index.js"
     },
     "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {
-      "config": [
-        "./dist/types/config.d.ts"
-      ],
-      "test": [
-        "./dist/types/test/index.d.ts"
-      ],
-      "zod": [
-        "./dist/types/zod/index.d.ts"
-      ]
+      "config": ["./dist/types/config.d.ts"],
+      "test": ["./dist/types/test/index.d.ts"],
+      "zod": ["./dist/types/zod/index.d.ts"]
     }
   },
   "peerDependencies": {
@@ -107,23 +101,14 @@
     "vitest": "^0.30.1",
     "zod": "^3.20.6"
   },
-  "contributors": [
-    "jxom.eth <j@wagmi.sh>",
-    "awkweb.eth <t@wagmi.sh>"
-  ],
+  "contributors": ["jxom.eth <j@wagmi.sh>", "awkweb.eth <t@wagmi.sh>"],
   "funding": [
     {
       "type": "github",
       "url": "https://github.com/sponsors/wagmi-dev"
     }
   ],
-  "keywords": [
-    "abi",
-    "eth",
-    "ethereum",
-    "typescript",
-    "web3"
-  ],
+  "keywords": ["abi", "eth", "ethereum", "typescript", "web3"],
   "simple-git-hooks": {
     "pre-commit": "pnpm format && pnpm lint:fix"
   },
@@ -134,9 +119,7 @@
       "shiki-twoslash>shiki": "^0.14.1"
     },
     "peerDependencyRules": {
-      "ignoreMissing": [
-        "@algolia/client-search"
-      ]
+      "ignoreMissing": ["@algolia/client-search"]
     }
   }
 }


### PR DESCRIPTION
## Description

Fixes package.json Zod entrypoint ESM path.

## Additional Information

- [x] I read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [x] I added documentation related to the changes made.
- [x] I added or updated tests related to the changes made.

Your ENS/address:


<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes the `package.json` Zod entrypoint ESM path.

### Detailed summary
- Fixed the `package.json` Zod entrypoint ESM path.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->