### PR TITLE
fix: no space returns

### DIFF
--- a/.changeset/small-dogs-turn.md
+++ b/.changeset/small-dogs-turn.md
@@ -2,4 +2,4 @@
 "abitype": patch
 ---
 
-Fixed a bug where function signatures with no space returns were not infering correct values.
+Fixed type-level issue with human-readable function signatures with no space returns.

--- a/.changeset/small-dogs-turn.md
+++ b/.changeset/small-dogs-turn.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+Fixed a bug where function signatures with no space returns were not infering correct values.

--- a/src/human-readable/types/utils.test-d.ts
+++ b/src/human-readable/types/utils.test-d.ts
@@ -279,6 +279,15 @@ test('ParseSignature', () => {
     inputs: [],
     outputs: [{ type: 'string', name: 'bar' }],
   })
+  assertType<
+    ParseSignature<'function foo() public payable returns(string bar)'>
+  >({
+    type: 'function',
+    name: 'foo',
+    stateMutability: 'payable',
+    inputs: [],
+    outputs: [{ type: 'string', name: 'bar' }],
+  })
 
   // inputs and outputs
   assertType<ParseSignature<'function foo(string) returns (string)'>>({
@@ -293,6 +302,15 @@ test('ParseSignature', () => {
     name: 'foo',
     stateMutability: 'nonpayable',
     inputs: [{ type: 'string', name: 'bar' }],
+    outputs: [{ type: 'string', name: 'bar' }],
+  })
+  assertType<
+    ParseSignature<'function foo(string foo) public payable returns(string bar)'>
+  >({
+    type: 'function',
+    name: 'foo',
+    stateMutability: 'payable',
+    inputs: [{ type: 'string', name: 'foo' }],
     outputs: [{ type: 'string', name: 'bar' }],
   })
   assertType<

--- a/src/human-readable/types/utils.ts
+++ b/src/human-readable/types/utils.ts
@@ -64,7 +64,9 @@ export type ParseSignature<
               >,
               { Modifier: FunctionModifier; Structs: TStructs }
             >
-            readonly outputs: Tail extends `${string}returns (${infer Returns})`
+            readonly outputs: Tail extends
+              | `${string}returns (${infer Returns})`
+              | `${string}returns(${infer Returns})`
               ? ParseAbiParameters<
                   SplitParameters<Returns>,
                   { Modifier: FunctionModifier; Structs: TStructs }
@@ -238,7 +240,9 @@ export type _ValidateAbiParameter<TAbiParameter extends AbiParameter> =
 
 export type _ParseFunctionParametersAndStateMutability<
   TSignature extends string,
-> = TSignature extends `${infer Head}returns (${string})`
+> = TSignature extends
+  | `${infer Head}returns (${string})`
+  | `${infer Head}returns(${string})`
   ? _ParseFunctionParametersAndStateMutability<Trim<Head>>
   : TSignature extends `function ${string}(${infer Parameters})`
   ? { Inputs: Parameters; StateMutability: 'nonpayable' }


### PR DESCRIPTION
## Additional Information

- [x] I read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [ ] I added documentation related to the changes made.
- [x] I added or updated tests related to the changes made.

Your ENS/address:

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes a type-level issue with human-readable function signatures in the codebase. 

### Detailed summary
- Fixed issue with human-readable function signatures with no space returns
- Added test cases for human-readable function signatures
- Improved code readability by refactoring and updating code comments

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->