### PR TITLE
fix: parseAbi with typescript@5.1.3

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        version: ['5.0.4', '5.1.3']
+        version: ['5.0.4', '5.1.3', 'latest']
 
     steps:
       - name: Clone repository
@@ -48,7 +48,7 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
 
-      - name: TypeScript ${{ matrix.version }}
+      - name: Use `typescript@${{ matrix.version }}`
         run: pnpm add -D -w typescript@${{ matrix.version }}
 
       - name: Build
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        version: ['5.0.4', '5.1.3']
+        version: ['5.0.4', '5.1.3', 'latest']
 
     steps:
       - name: Clone repository
@@ -75,7 +75,7 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
 
-      - name: TypeScript ${{ matrix.version }}
+      - name: Use `typescript@${{ matrix.version }}`
         run: pnpm add -D -w typescript@${{ matrix.version }}
 
       - name: Run tests

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -37,6 +37,9 @@ jobs:
     name: Types
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      matrix:
+        version: ['5.0.4', '5.1.3']
 
     steps:
       - name: Clone repository
@@ -44,6 +47,9 @@ jobs:
 
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
+
+      - name: TypeScript ${{ matrix.version }}
+        run: pnpm add -D -w typescript@${{ matrix.version }}
 
       - name: Build
         run: pnpm build
@@ -58,6 +64,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      matrix:
+        version: ['5.0.4', '5.1.3']
 
     steps:
       - name: Clone repository
@@ -65,6 +74,9 @@ jobs:
 
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
+
+      - name: TypeScript ${{ matrix.version }}
+        run: pnpm add -D -w typescript@${{ matrix.version }}
 
       - name: Run tests
         run: pnpm test:cov

--- a/examples/reads.ts
+++ b/examples/reads.ts
@@ -12,7 +12,7 @@ export declare function reads<
   functionName extends string,
   const args extends readonly unknown[] | undefined,
   contracts extends Contract<abi, functionName, args>[],
->(parameters: ReadsParameters<contracts>): ContractsReturnType<contracts>
+>(parameters: ReadsParameters<contracts>): ReadsResult<contracts>
 
 export declare function useReads<
   const abi extends Abi | readonly unknown[], // `readonly unknown[]` allows for non-const asserted types
@@ -20,8 +20,13 @@ export declare function useReads<
   const args extends readonly unknown[] | undefined,
   contracts extends Contract<abi, functionName, args>[],
 >(
-  parameters: DeepPartial<ReadsParameters<contracts>, 3>,
-): ContractsReturnType<contracts>
+  // TODO(@tmm): Broke for `typescript@5.1.3` https://github.com/wagmi-dev/abitype/issues/153
+  // parameters: DeepPartial<ReadsParameters<contracts>, 3>,
+  parameters: DeepPartial<
+    { contracts: readonly [...DeepPartial<ContractsParameters<contracts>, 2>] },
+    1
+  >,
+): ReadsResult<contracts>
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/package.json
+++ b/package.json
@@ -96,8 +96,8 @@
     "rimraf": "^5.0.1",
     "rome": "^12.1.3",
     "simple-git-hooks": "^2.8.1",
-    "typescript": "^5.0.4",
-    "typescript@5.1.3": "npm:typescript@^5.1.3",
+    "typescript": "5.0.4",
+    "typescript@5.1.3": "npm:typescript@5.1.3",
     "vitest": "^0.30.1",
     "zod": "^3.20.6"
   },

--- a/package.json
+++ b/package.json
@@ -69,15 +69,9 @@
   },
   "typesVersions": {
     "*": {
-      "config": [
-        "./dist/types/config.d.ts"
-      ],
-      "test": [
-        "./dist/types/test.d.ts"
-      ],
-      "zod": [
-        "./dist/types/zod.d.ts"
-      ]
+      "config": ["./dist/types/config.d.ts"],
+      "test": ["./dist/types/test.d.ts"],
+      "zod": ["./dist/types/zod.d.ts"]
     }
   },
   "peerDependencies": {
@@ -103,26 +97,18 @@
     "rome": "^12.1.3",
     "simple-git-hooks": "^2.8.1",
     "typescript": "^5.0.4",
+    "typescript@5.1.3": "npm:typescript@^5.1.3",
     "vitest": "^0.30.1",
     "zod": "^3.20.6"
   },
-  "contributors": [
-    "jxom.eth <j@wagmi.sh>",
-    "awkweb.eth <t@wagmi.sh>"
-  ],
+  "contributors": ["jxom.eth <j@wagmi.sh>", "awkweb.eth <t@wagmi.sh>"],
   "funding": [
     {
       "type": "github",
       "url": "https://github.com/sponsors/wagmi-dev"
     }
   ],
-  "keywords": [
-    "abi",
-    "eth",
-    "ethereum",
-    "typescript",
-    "web3"
-  ],
+  "keywords": ["abi", "eth", "ethereum", "typescript", "web3"],
   "simple-git-hooks": {
     "pre-commit": "pnpm format && pnpm lint:fix"
   },
@@ -133,9 +119,7 @@
       "shiki-twoslash>shiki": "^0.14.1"
     },
     "peerDependencyRules": {
-      "ignoreMissing": [
-        "@algolia/client-search"
-      ]
+      "ignoreMissing": ["@algolia/client-search"]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
+      typescript@5.1.3:
+        specifier: npm:typescript@^5.1.3
+        version: /typescript@5.1.3
       vitest:
         specifier: ^0.30.1
         version: 0.30.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,10 +45,10 @@ importers:
         specifier: ^2.8.1
         version: 2.8.1
       typescript:
-        specifier: ^5.0.4
+        specifier: 5.0.4
         version: 5.0.4
       typescript@5.1.3:
-        specifier: npm:typescript@^5.1.3
+        specifier: npm:typescript@5.1.3
         version: /typescript@5.1.3
       vitest:
         specifier: ^0.30.1
@@ -79,7 +79,7 @@ importers:
         version: 1.0.0-beta.1(@types/node@18.16.3)(search-insights@2.6.0)
       vitepress-plugin-shiki-twoslash:
         specifier: 0.0.6
-        version: 0.0.6(typescript@5.1.3)(vitepress@1.0.0-beta.1)
+        version: 0.0.6(typescript@5.0.4)(vitepress@1.0.0-beta.1)
       vue:
         specifier: ^3.3.4
         version: 3.3.4
@@ -3162,7 +3162,7 @@ packages:
       functions-have-names: 1.2.3
     dev: true
 
-  /remark-shiki-twoslash@3.1.3(typescript@5.1.3):
+  /remark-shiki-twoslash@3.1.3(typescript@5.0.4):
     resolution: {integrity: sha512-4e8OH3ySOCw5wUbDcPszokOKjKuebOqlP2WlySvC7ITBOq27BiGsFlq+FNWhxppZ+JzhTWah4gQrnMjX3KDbAQ==}
     peerDependencies:
       typescript: '>3'
@@ -3173,9 +3173,9 @@ packages:
       fenceparser: 1.1.1
       regenerator-runtime: 0.13.11
       shiki: 0.14.1
-      shiki-twoslash: 3.1.2(typescript@5.1.3)
+      shiki-twoslash: 3.1.2(typescript@5.0.4)
       tslib: 2.1.0
-      typescript: 5.1.3
+      typescript: 5.0.4
       unist-util-visit: 2.0.3
     transitivePeerDependencies:
       - supports-color
@@ -3315,7 +3315,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /shiki-twoslash@3.1.2(typescript@5.1.3):
+  /shiki-twoslash@3.1.2(typescript@5.0.4):
     resolution: {integrity: sha512-JBcRIIizi+exIA/OUhYkV6jtyeZco0ykCkIRd5sgwIt1Pm4pz+maoaRZpm6SkhPwvif4fCA7xOtJOykhpIV64Q==}
     peerDependencies:
       typescript: '>3'
@@ -3324,7 +3324,7 @@ packages:
       '@typescript/vfs': 1.3.4
       fenceparser: 1.1.1
       shiki: 0.14.1
-      typescript: 5.1.3
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3815,12 +3815,12 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitepress-plugin-shiki-twoslash@0.0.6(typescript@5.1.3)(vitepress@1.0.0-beta.1):
+  /vitepress-plugin-shiki-twoslash@0.0.6(typescript@5.0.4)(vitepress@1.0.0-beta.1):
     resolution: {integrity: sha512-CjMF01Vb/zwOKKCqq6QmkJbTJnRxipv8oiPjRWTjzH2jPaQH4gGCF2fZHS7uY53J3gbU3GwtrXI02J6axLYmbg==}
     peerDependencies:
       vitepress: '>=1.0.0-alpha.61'
     dependencies:
-      remark-shiki-twoslash: 3.1.3(typescript@5.1.3)
+      remark-shiki-twoslash: 3.1.3(typescript@5.0.4)
       vitepress: 1.0.0-beta.1(@types/node@18.16.3)(search-insights@2.6.0)
     transitivePeerDependencies:
       - supports-color

--- a/src/human-readable/types/signatures.ts
+++ b/src/human-readable/types/signatures.ts
@@ -106,6 +106,8 @@ export type Signature<
   K extends string | unknown = unknown,
 > = IsSignature<T> extends true
   ? T
+  : string extends T // if exactly `string` (not narrowed), then pass through as valid
+  ? T
   : Error<`Signature "${T}" is invalid${K extends string
       ? ` at position ${K}`
       : ''}.`>


### PR DESCRIPTION
## Description

Fixes https://github.com/wagmi-dev/abitype/issues/153

## Additional Information

- [x] I read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [ ] I added documentation related to the changes made.
- [x] I added or updated tests related to the changes made.

Your ENS/address:

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces changes to several files, including `src/human-readable/types/signatures.ts`, `examples/reads.ts`, `package.json`, `pnpm-lock.yaml`, and `src/human-readable/parseAbi.ts`. Notable changes include:

### Detailed summary
- `src/human-readable/types/signatures.ts`: 
  - Adds support for passing through a valid signature if it's exactly `string`
  - Updates the return type of `useReads` function
- `examples/reads.ts`: Updates the type of `parameters` in the `useReads` function
- `package.json` and `pnpm-lock.yaml`: Updates `typescript` version to `5.0.4` and adds support for `typescript@5.1.3`
- `src/human-readable/parseAbi.ts`: Updates the `parseAbi` function to use `const` for the generic type argument and simplifies the validation of the `signatures` argument

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->