### PR TITLE
refactor: typedata internal

### DIFF
--- a/.changeset/seven-cobras-kneel.md
+++ b/.changeset/seven-cobras-kneel.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+Switched `TypedData` from TypeScript object to Record.

--- a/src/abi.ts
+++ b/src/abi.ts
@@ -240,10 +240,8 @@ export type TypedDataParameter = {
  * [EIP-712](https://eips.ethereum.org/EIPS/eip-712#definition-of-typed-structured-data-%F0%9D%95%8A) Typed Data Specification
  */
 export type TypedData = Pretty<
-  {
-    [key: string]: readonly TypedDataParameter[]
-  } & {
+  Record<string, readonly TypedDataParameter[]> & {
     // Disallow `TypedDataType` as key names (e.g. `address`)
-    [_ in TypedDataType]?: never | undefined
+    [_ in TypedDataType]?: never
   }
 >


### PR DESCRIPTION
## Description

What changes are made in this PR? Is it a feature or a bug fix?

## Additional Information

- [ ] I read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [ ] I added documentation related to the changes made.
- [ ] I added or updated tests related to the changes made.

Your ENS/address:


<!-- start pr-codex -->

---

## PR-Codex overview
This PR switches `TypedData` from a TypeScript object to a `Record` and disallows `TypedDataType` as key names. 

### Detailed summary
- `TypedData` is now a `Record` instead of a TypeScript object
- `TypedDataType` is disallowed as key names

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->