### PR TITLE
fix(zod): improved tree shaking for `zod` entry 

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,15 +69,9 @@
   },
   "typesVersions": {
     "*": {
-      "config": [
-        "./dist/types/config.d.ts"
-      ],
-      "test": [
-        "./dist/types/test.d.ts"
-      ],
-      "zod": [
-        "./dist/types/zod.d.ts"
-      ]
+      "config": ["./dist/types/config.d.ts"],
+      "test": ["./dist/types/test.d.ts"],
+      "zod": ["./dist/types/zod.d.ts"]
     }
   },
   "peerDependencies": {
@@ -107,23 +101,14 @@
     "vitest": "^0.30.1",
     "zod": "^3.20.6"
   },
-  "contributors": [
-    "jxom.eth <j@wagmi.sh>",
-    "awkweb.eth <t@wagmi.sh>"
-  ],
+  "contributors": ["jxom.eth <j@wagmi.sh>", "awkweb.eth <t@wagmi.sh>"],
   "funding": [
     {
       "type": "github",
       "url": "https://github.com/sponsors/wagmi-dev"
     }
   ],
-  "keywords": [
-    "abi",
-    "eth",
-    "ethereum",
-    "typescript",
-    "web3"
-  ],
+  "keywords": ["abi", "eth", "ethereum", "typescript", "web3"],
   "simple-git-hooks": {
     "pre-commit": "pnpm format && pnpm lint:fix"
   },
@@ -134,9 +119,7 @@
       "shiki-twoslash>shiki": "^0.14.1"
     },
     "peerDependencyRules": {
-      "ignoreMissing": [
-        "@algolia/client-search"
-      ]
+      "ignoreMissing": ["@algolia/client-search"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "bench": "vitest bench",
     "build": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm && pnpm run build:types",
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --outDir ./dist/cjs --removeComments --verbatimModuleSyntax false && echo > ./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir ./dist/esm --removeComments && echo > ./dist/esm/package.json '{\"type\":\"module\",\"sideEffects\":false}'",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir ./dist/esm && echo > ./dist/esm/package.json '{\"type\":\"module\",\"sideEffects\":false}'",
     "build:types": "tsc --project tsconfig.build.json --module esnext --declarationDir ./dist/types --emitDeclarationOnly --declaration --declarationMap",
     "changeset": "changeset",
     "changeset:release": "pnpm build && changeset publish",

--- a/src/human-readable/runtime/cache.ts
+++ b/src/human-readable/runtime/cache.ts
@@ -19,7 +19,7 @@ export function getParameterCacheKey(
  *
  * **Note: When seeding more parameters, make sure you benchmark performance. The current number is the ideal balance between performance and having an already existing cache.**
  */
-export const parameterCache = new Map<
+export const parameterCache = /*#__PURE__*/ new Map<
   string,
   AbiParameter & { indexed?: boolean }
 >([

--- a/src/human-readable/runtime/signatures.ts
+++ b/src/human-readable/runtime/signatures.ts
@@ -85,14 +85,14 @@ export function isReceiveSignature(signature: string) {
   return receiveSignatureRegex.test(signature)
 }
 
-export const modifiers = new Set<Modifier>([
+export const modifiers = /*#__PURE__*/ new Set<Modifier>([
   'memory',
   'indexed',
   'storage',
   'calldata',
 ])
-export const eventModifiers = new Set<EventModifier>(['indexed'])
-export const functionModifiers = new Set<FunctionModifier>([
+export const eventModifiers = /*#__PURE__*/ new Set<EventModifier>(['indexed'])
+export const functionModifiers = /*#__PURE__*/ new Set<FunctionModifier>([
   'calldata',
   'memory',
   'storage',

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -10,192 +10,200 @@ import type {
 } from './abi.js'
 import { bytesRegex, integerRegex } from './regex.js'
 
-export const Address = z.string().transform((val, ctx) => {
-  const regex = /^0x[a-fA-F0-9]{40}$/
+export const Address = /*#__PURE__*/ (() =>
+  z.string().transform((val, ctx) => {
+    const regex = /^0x[a-fA-F0-9]{40}$/
 
-  if (!regex.test(val)) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: `Invalid Address ${val}`,
-    })
-  }
+    if (!regex.test(val)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Invalid Address ${val}`,
+      })
+    }
 
-  return val as AddressType
-})
+    return val as AddressType
+  }))()
 
 // From https://docs.soliditylang.org/en/latest/abi-spec.html#types
-export const SolidityAddress = z.literal('address')
-export const SolidityBool = z.literal('bool')
-export const SolidityBytes = z.string().regex(bytesRegex)
-export const SolidityFunction = z.literal('function')
-export const SolidityString = z.literal('string')
-export const SolidityTuple = z.literal('tuple')
-export const SolidityInt = z.string().regex(integerRegex)
-export const SolidityArrayWithoutTuple = z
-  .string()
-  .regex(
-    /^(address|bool|function|string|bytes([1-9]|1[0-9]|2[0-9]|3[0-2])?|u?int(8|16|24|32|40|48|56|64|72|80|88|96|104|112|120|128|136|144|152|160|168|176|184|192|200|208|216|224|232|240|248|256)?)(\[[0-9]{0,}\])+$/,
-  )
-export const SolidityArrayWithTuple = z
-  .string()
-  .regex(/^tuple(\[[0-9]{0,}\])+$/)
-export const SolidityArray = z.union([
-  SolidityArrayWithTuple,
-  SolidityArrayWithoutTuple,
-])
+export const SolidityAddress = /*#__PURE__*/ z.literal('address')
+export const SolidityBool = /*#__PURE__*/ z.literal('bool')
+export const SolidityBytes = /*#__PURE__*/ (() =>
+  z.string().regex(bytesRegex))()
+export const SolidityFunction = /*#__PURE__*/ z.literal('function')
+export const SolidityString = /*#__PURE__*/ z.literal('string')
+export const SolidityTuple = /*#__PURE__*/ z.literal('tuple')
+export const SolidityInt = /*#__PURE__*/ (() =>
+  z.string().regex(integerRegex))()
+export const SolidityArrayWithoutTuple = /*#__PURE__*/ (() =>
+  z
+    .string()
+    .regex(
+      /^(address|bool|function|string|bytes([1-9]|1[0-9]|2[0-9]|3[0-2])?|u?int(8|16|24|32|40|48|56|64|72|80|88|96|104|112|120|128|136|144|152|160|168|176|184|192|200|208|216|224|232|240|248|256)?)(\[[0-9]{0,}\])+$/,
+    ))()
+export const SolidityArrayWithTuple = /*#__PURE__*/ (() =>
+  z.string().regex(/^tuple(\[[0-9]{0,}\])+$/))()
+export const SolidityArray = /*#__PURE__*/ (() =>
+  z.union([SolidityArrayWithTuple, SolidityArrayWithoutTuple]))()
 
-export const AbiParameter: z.ZodType<AbiParameterType> = z.lazy(() =>
-  z.intersection(
+export const AbiParameter: z.ZodType<AbiParameterType> = /*#__PURE__*/ (() =>
+  z.lazy(() =>
+    z.intersection(
+      z.object({
+        name: z.string().optional(),
+        /** Representation used by Solidity compiler */
+        internalType: z.string().optional(),
+      }),
+      z.union([
+        z.object({
+          type: z.union([
+            SolidityAddress,
+            SolidityBool,
+            SolidityBytes,
+            SolidityFunction,
+            SolidityString,
+            SolidityInt,
+            SolidityArrayWithoutTuple,
+          ]),
+        }),
+        z.object({
+          type: z.union([SolidityTuple, SolidityArrayWithTuple]),
+          components: z.array(AbiParameter),
+        }),
+      ]),
+    ),
+  ))()
+
+export const AbiEventParameter = /*#__PURE__*/ (() =>
+  z.intersection(AbiParameter, z.object({ indexed: z.boolean().optional() })))()
+
+export const AbiStateMutability = /*#__PURE__*/ (() =>
+  z.union([
+    z.literal('pure'),
+    z.literal('view'),
+    z.literal('nonpayable'),
+    z.literal('payable'),
+  ]))()
+
+export const AbiFunction = /*#__PURE__*/ (() =>
+  z.preprocess(
+    (val) => {
+      const abiFunction = val as unknown as AbiFunctionType
+      // Calculate `stateMutability` for deprecated `constant` and `payable` fields
+      if (abiFunction.stateMutability === undefined) {
+        if (abiFunction.constant) abiFunction.stateMutability = 'view'
+        else if (abiFunction.payable) abiFunction.stateMutability = 'payable'
+        else abiFunction.stateMutability = 'nonpayable'
+      }
+      return val
+    },
     z.object({
-      name: z.string().optional(),
-      /** Representation used by Solidity compiler */
-      internalType: z.string().optional(),
+      type: z.literal('function'),
+      /**
+       * @deprecated use `pure` or `view` from {@link AbiStateMutability} instead
+       * https://github.com/ethereum/solidity/issues/992
+       */
+      constant: z.boolean().optional(),
+      /**
+       * @deprecated Vyper used to provide gas estimates
+       * https://github.com/vyperlang/vyper/issues/2151
+       */
+      gas: z.number().optional(),
+      inputs: z.array(AbiParameter),
+      name: z.string(),
+      outputs: z.array(AbiParameter),
+      /**
+       * @deprecated use `payable` or `nonpayable` from {@link AbiStateMutability} instead
+       * https://github.com/ethereum/solidity/issues/992
+       */
+      payable: z.boolean().optional(),
+      stateMutability: AbiStateMutability,
     }),
-    z.union([
-      z.object({
-        type: z.union([
-          SolidityAddress,
-          SolidityBool,
-          SolidityBytes,
-          SolidityFunction,
-          SolidityString,
-          SolidityInt,
-          SolidityArrayWithoutTuple,
-        ]),
-      }),
-      z.object({
-        type: z.union([SolidityTuple, SolidityArrayWithTuple]),
-        components: z.array(AbiParameter),
-      }),
-    ]),
-  ),
-)
+  ))()
 
-export const AbiEventParameter = z.intersection(
-  AbiParameter,
-  z.object({ indexed: z.boolean().optional() }),
-)
+export const AbiConstructor = /*#__PURE__*/ (() =>
+  z.preprocess(
+    (val) => {
+      const abiFunction = val as unknown as AbiConstructorType
+      // Calculate `stateMutability` for deprecated `payable` field
+      if (abiFunction.stateMutability === undefined) {
+        if (abiFunction.payable) abiFunction.stateMutability = 'payable'
+        else abiFunction.stateMutability = 'nonpayable'
+      }
+      return val
+    },
+    z.object({
+      type: z.literal('constructor'),
+      /**
+       * @deprecated use `pure` or `view` from {@link AbiStateMutability} instead
+       * https://github.com/ethereum/solidity/issues/992
+       */
+      inputs: z.array(AbiParameter),
+      /**
+       * @deprecated use `payable` or `nonpayable` from {@link AbiStateMutability} instead
+       * https://github.com/ethereum/solidity/issues/992
+       */
+      payable: z.boolean().optional(),
+      stateMutability: z.union([z.literal('nonpayable'), z.literal('payable')]),
+    }),
+  ))()
 
-export const AbiStateMutability = z.union([
-  z.literal('pure'),
-  z.literal('view'),
-  z.literal('nonpayable'),
-  z.literal('payable'),
-])
+export const AbiFallback = /*#__PURE__*/ (() =>
+  z.preprocess(
+    (val) => {
+      const abiFunction = val as unknown as AbiFallbackType
+      // Calculate `stateMutability` for deprecated `payable` field
+      if (abiFunction.stateMutability === undefined) {
+        if (abiFunction.payable) abiFunction.stateMutability = 'payable'
+        else abiFunction.stateMutability = 'nonpayable'
+      }
+      return val
+    },
+    z.object({
+      type: z.literal('fallback'),
+      /**
+       * @deprecated use `pure` or `view` from {@link AbiStateMutability} instead
+       * https://github.com/ethereum/solidity/issues/992
+       */
+      inputs: z.tuple([]).optional(),
+      /**
+       * @deprecated use `payable` or `nonpayable` from {@link AbiStateMutability} instead
+       * https://github.com/ethereum/solidity/issues/992
+       */
+      payable: z.boolean().optional(),
+      stateMutability: z.union([z.literal('nonpayable'), z.literal('payable')]),
+    }),
+  ))()
 
-export const AbiFunction = z.preprocess(
-  (val) => {
-    const abiFunction = val as unknown as AbiFunctionType
-    // Calculate `stateMutability` for deprecated `constant` and `payable` fields
-    if (abiFunction.stateMutability === undefined) {
-      if (abiFunction.constant) abiFunction.stateMutability = 'view'
-      else if (abiFunction.payable) abiFunction.stateMutability = 'payable'
-      else abiFunction.stateMutability = 'nonpayable'
-    }
-    return val
-  },
+export const AbiReceive = /*#__PURE__*/ (() =>
   z.object({
-    type: z.literal('function'),
-    /**
-     * @deprecated use `pure` or `view` from {@link AbiStateMutability} instead
-     * https://github.com/ethereum/solidity/issues/992
-     */
-    constant: z.boolean().optional(),
-    /**
-     * @deprecated Vyper used to provide gas estimates
-     * https://github.com/vyperlang/vyper/issues/2151
-     */
-    gas: z.number().optional(),
+    type: z.literal('receive'),
+    stateMutability: z.literal('payable'),
+  }))()
+
+export const AbiEvent = /*#__PURE__*/ (() =>
+  z.object({
+    type: z.literal('event'),
+    anonymous: z.boolean().optional(),
+    inputs: z.array(AbiEventParameter),
+    name: z.string(),
+  }))()
+
+export const AbiError = /*#__PURE__*/ (() =>
+  z.object({
+    type: z.literal('error'),
     inputs: z.array(AbiParameter),
     name: z.string(),
-    outputs: z.array(AbiParameter),
-    /**
-     * @deprecated use `payable` or `nonpayable` from {@link AbiStateMutability} instead
-     * https://github.com/ethereum/solidity/issues/992
-     */
-    payable: z.boolean().optional(),
-    stateMutability: AbiStateMutability,
-  }),
-)
+  }))()
 
-export const AbiConstructor = z.preprocess(
-  (val) => {
-    const abiFunction = val as unknown as AbiConstructorType
-    // Calculate `stateMutability` for deprecated `payable` field
-    if (abiFunction.stateMutability === undefined) {
-      if (abiFunction.payable) abiFunction.stateMutability = 'payable'
-      else abiFunction.stateMutability = 'nonpayable'
-    }
-    return val
-  },
-  z.object({
-    type: z.literal('constructor'),
-    /**
-     * @deprecated use `pure` or `view` from {@link AbiStateMutability} instead
-     * https://github.com/ethereum/solidity/issues/992
-     */
-    inputs: z.array(AbiParameter),
-    /**
-     * @deprecated use `payable` or `nonpayable` from {@link AbiStateMutability} instead
-     * https://github.com/ethereum/solidity/issues/992
-     */
-    payable: z.boolean().optional(),
-    stateMutability: z.union([z.literal('nonpayable'), z.literal('payable')]),
-  }),
-)
-
-export const AbiFallback = z.preprocess(
-  (val) => {
-    const abiFunction = val as unknown as AbiFallbackType
-    // Calculate `stateMutability` for deprecated `payable` field
-    if (abiFunction.stateMutability === undefined) {
-      if (abiFunction.payable) abiFunction.stateMutability = 'payable'
-      else abiFunction.stateMutability = 'nonpayable'
-    }
-    return val
-  },
-  z.object({
-    type: z.literal('fallback'),
-    /**
-     * @deprecated use `pure` or `view` from {@link AbiStateMutability} instead
-     * https://github.com/ethereum/solidity/issues/992
-     */
-    inputs: z.tuple([]).optional(),
-    /**
-     * @deprecated use `payable` or `nonpayable` from {@link AbiStateMutability} instead
-     * https://github.com/ethereum/solidity/issues/992
-     */
-    payable: z.boolean().optional(),
-    stateMutability: z.union([z.literal('nonpayable'), z.literal('payable')]),
-  }),
-)
-
-export const AbiReceive = z.object({
-  type: z.literal('receive'),
-  stateMutability: z.literal('payable'),
-})
-
-export const AbiEvent = z.object({
-  type: z.literal('event'),
-  anonymous: z.boolean().optional(),
-  inputs: z.array(AbiEventParameter),
-  name: z.string(),
-})
-
-export const AbiError = z.object({
-  type: z.literal('error'),
-  inputs: z.array(AbiParameter),
-  name: z.string(),
-})
-
-export const AbiItemType = z.union([
-  z.literal('constructor'),
-  z.literal('event'),
-  z.literal('error'),
-  z.literal('fallback'),
-  z.literal('function'),
-  z.literal('receive'),
-])
+export const AbiItemType = /*#__PURE__*/ (() =>
+  z.union([
+    z.literal('constructor'),
+    z.literal('event'),
+    z.literal('error'),
+    z.literal('fallback'),
+    z.literal('function'),
+    z.literal('receive'),
+  ]))()
 
 /**
  * Zod Schema for Contract [ABI Specification](https://docs.soliditylang.org/en/latest/abi-spec.html#json)
@@ -203,80 +211,85 @@ export const AbiItemType = z.union([
  * @example
  * const parsedAbi = Abi.parse([…])
  */
-export const Abi = z.array(
-  z.union([
-    AbiError,
-    AbiEvent,
-    // TODO: Replace code below to `z.switch` (https://github.com/colinhacks/zod/issues/2106)
-    // Need to redefine `AbiFunction | AbiConstructor | AbiFallback | AbiReceive` since `z.discriminate` doesn't support `z.preprocess` on `options`
-    // https://github.com/colinhacks/zod/issues/1490
-    z.preprocess(
-      (val) => {
-        const abiItem = val as
-          | AbiConstructorType
-          | AbiFallbackType
-          | AbiFunctionType
-          | AbiReceiveType
-        if (abiItem.type === 'receive') return abiItem
-        // Calculate `stateMutability` for deprecated fields: `constant` and `payable`
-        if (
-          (val as { stateMutability: AbiFunctionType['stateMutability'] })
-            .stateMutability === undefined
-        ) {
+export const Abi = /*#__PURE__*/ (() =>
+  z.array(
+    z.union([
+      AbiError,
+      AbiEvent,
+      // TODO: Replace code below to `z.switch` (https://github.com/colinhacks/zod/issues/2106)
+      // Need to redefine `AbiFunction | AbiConstructor | AbiFallback | AbiReceive` since `z.discriminate` doesn't support `z.preprocess` on `options`
+      // https://github.com/colinhacks/zod/issues/1490
+      z.preprocess(
+        (val) => {
+          const abiItem = val as
+            | AbiConstructorType
+            | AbiFallbackType
+            | AbiFunctionType
+            | AbiReceiveType
+          if (abiItem.type === 'receive') return abiItem
+          // Calculate `stateMutability` for deprecated fields: `constant` and `payable`
           if (
-            abiItem.type === 'function' &&
-            (abiItem as AbiFunctionType).constant
-          )
-            abiItem.stateMutability = 'view'
-          else if (
-            (abiItem as AbiConstructorType | AbiFallbackType | AbiFunctionType)
-              .payable
-          )
-            abiItem.stateMutability = 'payable'
-          else abiItem.stateMutability = 'nonpayable'
-        }
-        return val
-      },
-      z.intersection(
-        z.object({
-          /**
-           * @deprecated use `pure` or `view` from {@link AbiStateMutability} instead
-           * https://github.com/ethereum/solidity/issues/992
-           */
-          constant: z.boolean().optional(),
-          /**
-           * @deprecated Vyper used to provide gas estimates
-           * https://github.com/vyperlang/vyper/issues/2151
-           */
-          gas: z.number().optional(),
-          /**
-           * @deprecated use `payable` or `nonpayable` from {@link AbiStateMutability} instead
-           * https://github.com/ethereum/solidity/issues/992
-           */
-          payable: z.boolean().optional(),
-          stateMutability: AbiStateMutability,
-        }),
-        z.discriminatedUnion('type', [
+            (val as { stateMutability: AbiFunctionType['stateMutability'] })
+              .stateMutability === undefined
+          ) {
+            if (
+              abiItem.type === 'function' &&
+              (abiItem as AbiFunctionType).constant
+            )
+              abiItem.stateMutability = 'view'
+            else if (
+              (
+                abiItem as
+                  | AbiConstructorType
+                  | AbiFallbackType
+                  | AbiFunctionType
+              ).payable
+            )
+              abiItem.stateMutability = 'payable'
+            else abiItem.stateMutability = 'nonpayable'
+          }
+          return val
+        },
+        z.intersection(
           z.object({
-            type: z.literal('function'),
-            inputs: z.array(AbiParameter),
-            name: z.string(),
-            outputs: z.array(AbiParameter),
+            /**
+             * @deprecated use `pure` or `view` from {@link AbiStateMutability} instead
+             * https://github.com/ethereum/solidity/issues/992
+             */
+            constant: z.boolean().optional(),
+            /**
+             * @deprecated Vyper used to provide gas estimates
+             * https://github.com/vyperlang/vyper/issues/2151
+             */
+            gas: z.number().optional(),
+            /**
+             * @deprecated use `payable` or `nonpayable` from {@link AbiStateMutability} instead
+             * https://github.com/ethereum/solidity/issues/992
+             */
+            payable: z.boolean().optional(),
+            stateMutability: AbiStateMutability,
           }),
-          z.object({
-            type: z.literal('constructor'),
-            inputs: z.array(AbiParameter),
-          }),
-          z.object({
-            type: z.literal('fallback'),
-            inputs: z.tuple([]).optional(),
-          }),
-          z.object({
-            type: z.literal('receive'),
-            stateMutability: z.literal('payable'),
-          }),
-        ]),
+          z.discriminatedUnion('type', [
+            z.object({
+              type: z.literal('function'),
+              inputs: z.array(AbiParameter),
+              name: z.string(),
+              outputs: z.array(AbiParameter),
+            }),
+            z.object({
+              type: z.literal('constructor'),
+              inputs: z.array(AbiParameter),
+            }),
+            z.object({
+              type: z.literal('fallback'),
+              inputs: z.tuple([]).optional(),
+            }),
+            z.object({
+              type: z.literal('receive'),
+              stateMutability: z.literal('payable'),
+            }),
+          ]),
+        ),
       ),
-    ),
-  ]),
-)
+    ]),
+  ))()


### PR DESCRIPTION
## Description

improved tree shaking for `zod` entry

bundle size dropped from `813 B` to `26 B` (min + gzip) for 

```js
import { SolidityBool } from 'abitype/zod'
```

## Additional Information

- [x] I read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [ ] I added documentation related to the changes made.
- [ ] I added or updated tests related to the changes made.




<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving code readability and performance. 

### Detailed summary
- The `parameterCache` map in `cache.ts` is now initialized using a comment. 
- The `modifiers` and `eventModifiers` sets in `signatures.ts` are now initialized using a comment. 
- The `build:esm` script in `package.json` has been modified. 
- The `keywords` and `contributors` fields in `package.json` are now formatted as arrays. 
- The `AbiParameter`, `AbiEventParameter`, `AbiStateMutability`, `AbiFunction`, `AbiConstructor`, and `AbiFallback` types in `zod.ts` have been modified for better code organization and readability.

> The following files were skipped due to too many changes: `src/zod.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->