### PR TITLE
fix: mark typescript as optional peer dependency

### DIFF
--- a/.changeset/orange-chicken-remember.md
+++ b/.changeset/orange-chicken-remember.md
@@ -1,5 +1,5 @@
 ---
-"abitype": patch
+"abitype": minor
 ---
 
 Marked TypeScript as optional peer dependency

--- a/.changeset/orange-chicken-remember.md
+++ b/.changeset/orange-chicken-remember.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+Marked TypeScript as optional peer dependency

--- a/package.json
+++ b/package.json
@@ -85,6 +85,9 @@
     "zod": "^3 >=3.19.1"
   },
   "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    },
     "zod": {
       "optional": true
     }


### PR DESCRIPTION
## Description

Marks TypeScript as optional peer dependency so it isn't automatically installed by npm >=7.

## Additional Information

- [x] I read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [ ] I added documentation related to the changes made.
- [ ] I added or updated tests related to the changes made.

Your ENS/address: frangio.eth

<!-- start pr-codex -->

---

## PR-Codex overview
This PR marks TypeScript as an optional peer dependency and updates the `package.json` and `.changeset` files accordingly.

### Detailed summary:
- Marked TypeScript as an optional peer dependency in `package.json`
- Added a new `.changeset` file with the change summarized as "abitype: minor"
- Updated the `.changeset` file to include the specific change of marking TypeScript as optional

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->