### PR TITLE
fix(human-readable): formatAbiParameter incorrect inference

### DIFF
--- a/.changeset/violet-zoos-search.md
+++ b/.changeset/violet-zoos-search.md
@@ -18,8 +18,8 @@ After:
 
 ```ts
 type test = FormatAbiParameter<{
+//   ^? type test = "((string))"
   type: "tuple";
   components: [{ type: "tuple"; components: [{ type: "string" }] }];
 }>;
-//    ^? '((string))'
 ```

--- a/.changeset/violet-zoos-search.md
+++ b/.changeset/violet-zoos-search.md
@@ -2,7 +2,7 @@
 "abitype": patch
 ---
 
-Fixed a bug on `formatAbiParameter` where it would infer incorrectly the nested elements of the `components` property if it had no `name` property.
+Fixed a bug on `formatAbiParameter` where it would infer incorrectly the nested elements of the `components` property if it had no `name` property if the type was of `tuple` type.
 
 Before:
 

--- a/.changeset/violet-zoos-search.md
+++ b/.changeset/violet-zoos-search.md
@@ -2,7 +2,7 @@
 "abitype": patch
 ---
 
-Fixed a bug on `formatAbiParameter` where it would infer incorrectly the nested elements of the `components` property if it had no `name` property if the type was of `tuple` type.
+Fixed a bug on `formatAbiParameter` where it would infer incorrectly if the nested elements of the `components` property had no `name` property and the `type` property was of type `tuple` type.
 
 Before:
 

--- a/.changeset/violet-zoos-search.md
+++ b/.changeset/violet-zoos-search.md
@@ -1,0 +1,25 @@
+---
+"abitype": patch
+---
+
+Fixed a bug on `formatAbiParameter` where it would infer incorrectly the nested elements of the `components` property if it had no `name` property.
+
+Before:
+
+```ts
+type test = FormatAbiParameter<{
+  type: "tuple";
+  components: [{ type: "tuple"; components: [{ type: "string" }] }];
+}>;
+//    ^? '(tuple)'
+```
+
+After:
+
+```ts
+type test = FormatAbiParameter<{
+  type: "tuple";
+  components: [{ type: "tuple"; components: [{ type: "string" }] }];
+}>;
+//    ^? '((string))'
+```

--- a/.changeset/violet-zoos-search.md
+++ b/.changeset/violet-zoos-search.md
@@ -8,10 +8,10 @@ Before:
 
 ```ts
 type test = FormatAbiParameter<{
+//   ^? test = "(tuple)"
   type: "tuple";
   components: [{ type: "tuple"; components: [{ type: "string" }] }];
 }>;
-//    ^? '(tuple)'
 ```
 
 After:

--- a/src/config.test-d.ts
+++ b/src/config.test-d.ts
@@ -3,7 +3,7 @@ import { assertType, test } from 'vitest'
 import type { ResolvedConfig } from './config.js'
 
 // For testing updates to config properties:
-// declare module './config' {
+// declare module './config.js' {
 //   export interface Config {
 //     FixedArrayMaxLength: 6
 //   }

--- a/src/human-readable/formatAbiItem.test-d.ts
+++ b/src/human-readable/formatAbiItem.test-d.ts
@@ -39,7 +39,7 @@ test('FormatAbiItem', () => {
       readonly inputs: readonly []
       readonly outputs: readonly []
     }>
-  >().toEqualTypeOf<'function Error: "address" is a protected Solidity keyword.()'>()
+  >().toEqualTypeOf<'function [Error: "address" is a protected Solidity keyword.]()'>()
 
   expectTypeOf<
     FormatAbiItem<{

--- a/src/human-readable/formatAbiItem.test-d.ts
+++ b/src/human-readable/formatAbiItem.test-d.ts
@@ -33,6 +33,16 @@ test('FormatAbiItem', () => {
 
   expectTypeOf<
     FormatAbiItem<{
+      readonly name: 'address'
+      readonly type: 'function'
+      readonly stateMutability: 'nonpayable'
+      readonly inputs: readonly []
+      readonly outputs: readonly []
+    }>
+  >().toEqualTypeOf<'function Error: "address" is a protected Solidity keyword.()'>()
+
+  expectTypeOf<
+    FormatAbiItem<{
       readonly name: 'Transfer'
       readonly type: 'event'
       readonly inputs: readonly [

--- a/src/human-readable/formatAbiItem.ts
+++ b/src/human-readable/formatAbiItem.ts
@@ -14,6 +14,7 @@ import {
   type FormatAbiParameters as FormatAbiParameters_,
   formatAbiParameters,
 } from './formatAbiParameters.js'
+import type { AssertName } from './types/signatures.js'
 
 /**
  * Formats ABI item (e.g. error, event, function) into human-readable ABI item
@@ -28,7 +29,7 @@ export type FormatAbiItem<TAbiItem extends Abi[number]> =
         | (TAbiItem extends AbiFunction
             ? AbiFunction extends TAbiItem
               ? string
-              : `function ${TAbiItem['name']}(${FormatAbiParameters<
+              : `function ${AssertName<TAbiItem['name']>}(${FormatAbiParameters<
                   TAbiItem['inputs']
                 >})${TAbiItem['stateMutability'] extends Exclude<
                   AbiStateMutability,
@@ -42,14 +43,14 @@ export type FormatAbiItem<TAbiItem extends Abi[number]> =
         | (TAbiItem extends AbiEvent
             ? AbiEvent extends TAbiItem
               ? string
-              : `event ${TAbiItem['name']}(${FormatAbiParameters<
+              : `event ${AssertName<TAbiItem['name']>}(${FormatAbiParameters<
                   TAbiItem['inputs']
                 >})`
             : never)
         | (TAbiItem extends AbiError
             ? AbiError extends TAbiItem
               ? string
-              : `error ${TAbiItem['name']}(${FormatAbiParameters<
+              : `error ${AssertName<TAbiItem['name']>}(${FormatAbiParameters<
                   TAbiItem['inputs']
                 >})`
             : never)

--- a/src/human-readable/formatAbiParameter.test-d.ts
+++ b/src/human-readable/formatAbiParameter.test-d.ts
@@ -26,14 +26,14 @@ test('FormatAbiParameter', () => {
       type: 'address'
       name: 'address'
     }>
-  >().toEqualTypeOf<'address Error: "address" is a protected Solidity keyword.'>()
+  >().toEqualTypeOf<'address [Error: "address" is a protected Solidity keyword.]'>()
 
   expectTypeOf<
     FormatAbiParameter<{
       type: 'address'
       name: '123'
     }>
-  >().toEqualTypeOf<'address Error: Identifier "123" cannot be a number string.'>()
+  >().toEqualTypeOf<'address [Error: Identifier "123" cannot be a number string.]'>()
 
   // Array
   expectTypeOf<

--- a/src/human-readable/formatAbiParameter.test-d.ts
+++ b/src/human-readable/formatAbiParameter.test-d.ts
@@ -6,115 +6,115 @@ import type { FormatAbiParameter } from './formatAbiParameter.js'
 import { formatAbiParameter } from './formatAbiParameter.js'
 
 test('FormatAbiParameter', () => {
-    // string
-    expectTypeOf<
-        FormatAbiParameter<{
-            readonly type: 'address'
-            readonly name: 'from'
-        }>
-    >().toEqualTypeOf<'address from'>()
-    expectTypeOf<
-        FormatAbiParameter<{
-            readonly type: 'address'
-            readonly name: 'from'
-            readonly indexed: true
-        }>
-    >().toEqualTypeOf<'address indexed from'>()
+  // string
+  expectTypeOf<
+    FormatAbiParameter<{
+      readonly type: 'address'
+      readonly name: 'from'
+    }>
+  >().toEqualTypeOf<'address from'>()
+  expectTypeOf<
+    FormatAbiParameter<{
+      readonly type: 'address'
+      readonly name: 'from'
+      readonly indexed: true
+    }>
+  >().toEqualTypeOf<'address indexed from'>()
 
-    expectTypeOf<
-        FormatAbiParameter<{
-            type: 'address'
-            name: 'address'
-        }>
-    >().toEqualTypeOf<'address Error: "address" is a protected Solidity keyword.'>()
+  expectTypeOf<
+    FormatAbiParameter<{
+      type: 'address'
+      name: 'address'
+    }>
+  >().toEqualTypeOf<'address Error: "address" is a protected Solidity keyword.'>()
 
-    expectTypeOf<
-        FormatAbiParameter<{
-            type: 'address'
-            name: '123'
-        }>
-    >().toEqualTypeOf<'address Error: Identifier "123" cannot be a number string.'>()
+  expectTypeOf<
+    FormatAbiParameter<{
+      type: 'address'
+      name: '123'
+    }>
+  >().toEqualTypeOf<'address Error: Identifier "123" cannot be a number string.'>()
 
-    // Array
-    expectTypeOf<
-        FormatAbiParameter<{
-            readonly type: 'tuple'
-            readonly components: readonly [
+  // Array
+  expectTypeOf<
+    FormatAbiParameter<{
+      readonly type: 'tuple'
+      readonly components: readonly [
+        {
+          readonly name: 'name'
+          readonly type: 'string'
+        },
+      ]
+    }>
+  >().toEqualTypeOf<'(string name)'>()
+
+  expectTypeOf<
+    FormatAbiParameter<{
+      readonly type: 'tuple'
+      readonly components: readonly [
+        {
+          readonly type: 'string'
+          readonly name: 'bar'
+        },
+      ]
+      readonly name: 'foo'
+    }>
+  >().toEqualTypeOf<'(string bar) foo'>()
+
+  expectTypeOf<
+    FormatAbiParameter<{
+      readonly components: [
+        {
+          readonly components: [
+            {
+              readonly type: 'string'
+              readonly name: 'foo'
+            },
+          ]
+          readonly type: 'tuple'
+        },
+      ]
+      readonly type: 'tuple'
+    }>
+  >().toEqualTypeOf<'((string foo))'>()
+
+  expectTypeOf<
+    FormatAbiParameter<{
+      readonly components: [
+        {
+          readonly components: [
+            {
+              readonly components: [
                 {
-                    readonly name: 'name'
-                    readonly type: 'string'
+                  readonly components: [
+                    {
+                      readonly type: 'string'
+                    },
+                  ]
+                  readonly type: 'tuple'
                 },
-            ]
-        }>
-    >().toEqualTypeOf<'(string name)'>()
-
-    expectTypeOf<
-        FormatAbiParameter<{
-            readonly type: 'tuple'
-            readonly components: readonly [
-                {
-                    readonly type: 'string'
-                    readonly name: 'bar'
-                },
-            ]
-            readonly name: 'foo'
-        }>
-    >().toEqualTypeOf<'(string bar) foo'>()
-
-    expectTypeOf<
-        FormatAbiParameter<{
-            readonly components: [
-                {
-                    readonly components: [
-                        {
-                            readonly type: 'string'
-                            readonly name: 'foo'
-                        },
-                    ]
-                    readonly type: 'tuple'
-                },
-            ]
-            readonly type: 'tuple'
-        }>
-    >().toEqualTypeOf<'((string foo))'>()
-
-    expectTypeOf<
-        FormatAbiParameter<{
-            readonly components: [
-                {
-                    readonly components: [
-                        {
-                            readonly components: [
-                                {
-                                    readonly components: [
-                                        {
-                                            readonly type: 'string'
-                                        },
-                                    ]
-                                    readonly type: 'tuple'
-                                },
-                            ]
-                            readonly type: 'tuple'
-                        },
-                    ]
-                    readonly type: 'tuple'
-                },
-            ]
-            readonly type: 'tuple'
-        }>
-    >().toEqualTypeOf<'((((string))))'>()
+              ]
+              readonly type: 'tuple'
+            },
+          ]
+          readonly type: 'tuple'
+        },
+      ]
+      readonly type: 'tuple'
+    }>
+  >().toEqualTypeOf<'((((string))))'>()
 })
 
 test('formatAbiParameter', () => {
-    expectTypeOf(
-        formatAbiParameter({
-            type: 'tuple',
-            components: [{ type: 'string' }],
-        }),
-    ).toEqualTypeOf<'(string)'>()
+  expectTypeOf(
+    formatAbiParameter({
+      type: 'tuple',
+      components: [{ type: 'string' }],
+    }),
+  ).toEqualTypeOf<'(string)'>()
 
-    const param = { type: 'address' }
-    const param2: AbiParameter = param
-    expectTypeOf(formatAbiParameter(param)).toEqualTypeOf<string>()
-    expectTypeOf(formatAbiParameter(param2)).toEqualTypeOf<string>()
+  const param = { type: 'address' }
+  const param2: AbiParameter = param
+  expectTypeOf(formatAbiParameter(param)).toEqualTypeOf<string>()
+  expectTypeOf(formatAbiParameter(param2)).toEqualTypeOf<string>()
 })

--- a/src/human-readable/formatAbiParameter.test-d.ts
+++ b/src/human-readable/formatAbiParameter.test-d.ts
@@ -21,6 +21,20 @@ test('FormatAbiParameter', () => {
     }>
   >().toEqualTypeOf<'address indexed from'>()
 
+  expectTypeOf<
+    FormatAbiParameter<{
+      type: 'address'
+      name: 'address'
+    }>
+  >().toEqualTypeOf<'address Error: "address" is a protected Solidity keyword.'>()
+
+  expectTypeOf<
+    FormatAbiParameter<{
+      type: 'address'
+      name: '123'
+    }>
+  >().toEqualTypeOf<'address Error: Identifier "123" cannot be a number string.'>()
+
   // Array
   expectTypeOf<
     FormatAbiParameter<{
@@ -46,6 +60,50 @@ test('FormatAbiParameter', () => {
       readonly name: 'foo'
     }>
   >().toEqualTypeOf<'(string bar) foo'>()
+
+  expectTypeOf<
+    FormatAbiParameter<{
+      readonly components: [
+        {
+          readonly components: [
+            {
+              readonly type: 'string'
+              readonly name: 'foo'
+            },
+          ]
+          readonly name: string
+          readonly type: 'tuple'
+        },
+      ]
+      readonly type: 'tuple'
+    }>
+  >().toEqualTypeOf<'((string foo))'>()
+
+  expectTypeOf<
+    FormatAbiParameter<{
+      readonly components: [
+        {
+          readonly components: [
+            {
+              readonly components: [
+                {
+                  readonly components: [
+                    {
+                      readonly type: 'string'
+                    },
+                  ]
+                  readonly type: 'tuple'
+                },
+              ]
+              readonly type: 'tuple'
+            },
+          ]
+          readonly type: 'tuple'
+        },
+      ]
+      readonly type: 'tuple'
+    }>
+  >().toEqualTypeOf<'((((string))))'>()
 })
 
 test('formatAbiParameter', () => {

--- a/src/human-readable/formatAbiParameter.test-d.ts
+++ b/src/human-readable/formatAbiParameter.test-d.ts
@@ -6,116 +6,115 @@ import type { FormatAbiParameter } from './formatAbiParameter.js'
 import { formatAbiParameter } from './formatAbiParameter.js'
 
 test('FormatAbiParameter', () => {
-  // string
-  expectTypeOf<
-    FormatAbiParameter<{
-      readonly type: 'address'
-      readonly name: 'from'
-    }>
-  >().toEqualTypeOf<'address from'>()
-  expectTypeOf<
-    FormatAbiParameter<{
-      readonly type: 'address'
-      readonly name: 'from'
-      readonly indexed: true
-    }>
-  >().toEqualTypeOf<'address indexed from'>()
+    // string
+    expectTypeOf<
+        FormatAbiParameter<{
+            readonly type: 'address'
+            readonly name: 'from'
+        }>
+    >().toEqualTypeOf<'address from'>()
+    expectTypeOf<
+        FormatAbiParameter<{
+            readonly type: 'address'
+            readonly name: 'from'
+            readonly indexed: true
+        }>
+    >().toEqualTypeOf<'address indexed from'>()
 
-  expectTypeOf<
-    FormatAbiParameter<{
-      type: 'address'
-      name: 'address'
-    }>
-  >().toEqualTypeOf<'address Error: "address" is a protected Solidity keyword.'>()
+    expectTypeOf<
+        FormatAbiParameter<{
+            type: 'address'
+            name: 'address'
+        }>
+    >().toEqualTypeOf<'address Error: "address" is a protected Solidity keyword.'>()
 
-  expectTypeOf<
-    FormatAbiParameter<{
-      type: 'address'
-      name: '123'
-    }>
-  >().toEqualTypeOf<'address Error: Identifier "123" cannot be a number string.'>()
+    expectTypeOf<
+        FormatAbiParameter<{
+            type: 'address'
+            name: '123'
+        }>
+    >().toEqualTypeOf<'address Error: Identifier "123" cannot be a number string.'>()
 
-  // Array
-  expectTypeOf<
-    FormatAbiParameter<{
-      readonly type: 'tuple'
-      readonly components: readonly [
-        {
-          readonly name: 'name'
-          readonly type: 'string'
-        },
-      ]
-    }>
-  >().toEqualTypeOf<'(string name)'>()
-
-  expectTypeOf<
-    FormatAbiParameter<{
-      readonly type: 'tuple'
-      readonly components: readonly [
-        {
-          readonly type: 'string'
-          readonly name: 'bar'
-        },
-      ]
-      readonly name: 'foo'
-    }>
-  >().toEqualTypeOf<'(string bar) foo'>()
-
-  expectTypeOf<
-    FormatAbiParameter<{
-      readonly components: [
-        {
-          readonly components: [
-            {
-              readonly type: 'string'
-              readonly name: 'foo'
-            },
-          ]
-          readonly name: string
-          readonly type: 'tuple'
-        },
-      ]
-      readonly type: 'tuple'
-    }>
-  >().toEqualTypeOf<'((string foo))'>()
-
-  expectTypeOf<
-    FormatAbiParameter<{
-      readonly components: [
-        {
-          readonly components: [
-            {
-              readonly components: [
+    // Array
+    expectTypeOf<
+        FormatAbiParameter<{
+            readonly type: 'tuple'
+            readonly components: readonly [
                 {
-                  readonly components: [
-                    {
-                      readonly type: 'string'
-                    },
-                  ]
-                  readonly type: 'tuple'
+                    readonly name: 'name'
+                    readonly type: 'string'
                 },
-              ]
-              readonly type: 'tuple'
-            },
-          ]
-          readonly type: 'tuple'
-        },
-      ]
-      readonly type: 'tuple'
-    }>
-  >().toEqualTypeOf<'((((string))))'>()
+            ]
+        }>
+    >().toEqualTypeOf<'(string name)'>()
+
+    expectTypeOf<
+        FormatAbiParameter<{
+            readonly type: 'tuple'
+            readonly components: readonly [
+                {
+                    readonly type: 'string'
+                    readonly name: 'bar'
+                },
+            ]
+            readonly name: 'foo'
+        }>
+    >().toEqualTypeOf<'(string bar) foo'>()
+
+    expectTypeOf<
+        FormatAbiParameter<{
+            readonly components: [
+                {
+                    readonly components: [
+                        {
+                            readonly type: 'string'
+                            readonly name: 'foo'
+                        },
+                    ]
+                    readonly type: 'tuple'
+                },
+            ]
+            readonly type: 'tuple'
+        }>
+    >().toEqualTypeOf<'((string foo))'>()
+
+    expectTypeOf<
+        FormatAbiParameter<{
+            readonly components: [
+                {
+                    readonly components: [
+                        {
+                            readonly components: [
+                                {
+                                    readonly components: [
+                                        {
+                                            readonly type: 'string'
+                                        },
+                                    ]
+                                    readonly type: 'tuple'
+                                },
+                            ]
+                            readonly type: 'tuple'
+                        },
+                    ]
+                    readonly type: 'tuple'
+                },
+            ]
+            readonly type: 'tuple'
+        }>
+    >().toEqualTypeOf<'((((string))))'>()
 })
 
 test('formatAbiParameter', () => {
-  expectTypeOf(
-    formatAbiParameter({
-      type: 'tuple',
-      components: [{ type: 'string' }],
-    }),
-  ).toEqualTypeOf<'(string)'>()
+    expectTypeOf(
+        formatAbiParameter({
+            type: 'tuple',
+            components: [{ type: 'string' }],
+        }),
+    ).toEqualTypeOf<'(string)'>()
 
-  const param = { type: 'address' }
-  const param2: AbiParameter = param
-  expectTypeOf(formatAbiParameter(param)).toEqualTypeOf<string>()
-  expectTypeOf(formatAbiParameter(param2)).toEqualTypeOf<string>()
+    const param = { type: 'address' }
+    const param2: AbiParameter = param
+    expectTypeOf(formatAbiParameter(param)).toEqualTypeOf<string>()
+    expectTypeOf(formatAbiParameter(param2)).toEqualTypeOf<string>()
 })

--- a/src/human-readable/formatAbiParameter.ts
+++ b/src/human-readable/formatAbiParameter.ts
@@ -1,6 +1,7 @@
 import type { AbiEventParameter, AbiParameter } from '../abi.js'
 import { execTyped } from '../regex.js'
 import type { IsNarrowable, Join } from '../types.js'
+import type { ValidateName } from './types/signatures.js'
 
 /**
  * Formats {@link AbiParameter} to human-readable ABI parameter.
@@ -45,7 +46,9 @@ export type FormatAbiParameter<
   : `${TAbiParameter['type']}${TAbiParameter extends { indexed: true }
       ? ' indexed'
       : ''}${TAbiParameter['name'] extends infer Name extends string
-      ? ` ${Name}`
+      ? ` ${ValidateName<Name> extends infer InvalidName extends string[]
+          ? InvalidName[number]
+          : Name}`
       : ''}`
 
 // https://regexr.com/7f7rv

--- a/src/human-readable/formatAbiParameter.ts
+++ b/src/human-readable/formatAbiParameter.ts
@@ -1,7 +1,7 @@
 import type { AbiEventParameter, AbiParameter } from '../abi.js'
 import { execTyped } from '../regex.js'
 import type { IsNarrowable, Join } from '../types.js'
-import type { ValidateName } from './types/signatures.js'
+import type { AssertName } from './types/signatures.js'
 
 /**
  * Formats {@link AbiParameter} to human-readable ABI parameter.
@@ -46,9 +46,7 @@ export type FormatAbiParameter<
   : `${TAbiParameter['type']}${TAbiParameter extends { indexed: true }
       ? ' indexed'
       : ''}${TAbiParameter['name'] extends infer Name extends string
-      ? ` ${ValidateName<Name> extends infer InvalidName extends string[]
-          ? InvalidName[number]
-          : Name}`
+      ? ` ${AssertName<Name>}`
       : ''}`
 
 // https://regexr.com/7f7rv

--- a/src/human-readable/types/signatures.ts
+++ b/src/human-readable/types/signatures.ts
@@ -131,7 +131,7 @@ export type IsName<TName extends string> = TName extends ''
 
 export type AssertName<TName extends string> =
   ValidateName<TName> extends infer InvalidName extends string[]
-    ? InvalidName[number]
+    ? `[${InvalidName[number]}]`
     : TName
 
 export type ValidateName<

--- a/src/human-readable/types/signatures.ts
+++ b/src/human-readable/types/signatures.ts
@@ -128,6 +128,12 @@ export type IsName<TName extends string> = TName extends ''
   : ValidateName<TName> extends TName
   ? true
   : false
+
+export type AssertName<TName extends string> =
+  ValidateName<TName> extends infer InvalidName extends string[]
+    ? InvalidName[number]
+    : TName
+
 export type ValidateName<
   TName extends string,
   CheckCharacters extends boolean = false,
@@ -218,14 +224,14 @@ export type IsValidCharacter<T extends string> =
 
 // rome-ignore format: no formatting
 type ValidCharacters =
-  // uppercase letters
-  | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z'
-  // lowercase letters
-  | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z'
-  // numbers
-  | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
-  // special characters
-  | '_' | '$'
+    // uppercase letters
+    | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z'
+    // lowercase letters
+    | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z'
+    // numbers
+    | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
+    // special characters
+    | '_' | '$'
 
 // Template string inference can absorb `returns`:
 // type Result = `function foo(string) return s (uint256)` extends `function ${string}(${infer Parameters})` ? Parameters : never

--- a/src/human-readable/types/signatures.ts
+++ b/src/human-readable/types/signatures.ts
@@ -1,4 +1,4 @@
-import type { AbiStateMutability, AbiType } from '../../abi.js'
+import type { AbiStateMutability } from '../../abi.js'
 import type { Error } from '../../types.js'
 
 export type ErrorSignature<
@@ -213,7 +213,12 @@ export type SolidityKeywords =
   | 'var'
   | 'view'
   | 'virtual'
-  | AbiType
+  | `address${`[${string}]` | ''}`
+  | `boolean${`[${string}]` | ''}`
+  | `string${`[${string}]` | ''}`
+  | `tuple${`[${string}]` | ''}`
+  | `bytes${number | ''}${`[${string}]` | ''}`
+  | `${'u' | ''}int${number | ''}${`[${string}]` | ''}`
 
 export type IsValidCharacter<T extends string> =
   T extends `${ValidCharacters}${infer Tail}`
@@ -224,14 +229,14 @@ export type IsValidCharacter<T extends string> =
 
 // rome-ignore format: no formatting
 type ValidCharacters =
-    // uppercase letters
-    | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z'
-    // lowercase letters
-    | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z'
-    // numbers
-    | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
-    // special characters
-    | '_' | '$'
+  // uppercase letters
+  | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z'
+  // lowercase letters
+  | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z'
+  // numbers
+  | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
+  // special characters
+  | '_' | '$'
 
 // Template string inference can absorb `returns`:
 // type Result = `function foo(string) return s (uint256)` extends `function ${string}(${infer Parameters})` ? Parameters : never

--- a/src/human-readable/types/signatures.ts
+++ b/src/human-readable/types/signatures.ts
@@ -214,7 +214,7 @@ export type SolidityKeywords =
   | 'view'
   | 'virtual'
   | `address${`[${string}]` | ''}`
-  | `boolean${`[${string}]` | ''}`
+  | `bool${`[${string}]` | ''}`
   | `string${`[${string}]` | ''}`
   | `tuple${`[${string}]` | ''}`
   | `bytes${number | ''}${`[${string}]` | ''}`

--- a/src/human-readable/types/signatures.ts
+++ b/src/human-readable/types/signatures.ts
@@ -1,4 +1,4 @@
-import type { AbiStateMutability } from '../../abi.js'
+import type { AbiStateMutability, AbiType } from '../../abi.js'
 import type { Error } from '../../types.js'
 
 export type ErrorSignature<
@@ -207,6 +207,7 @@ export type SolidityKeywords =
   | 'var'
   | 'view'
   | 'virtual'
+  | AbiType
 
 export type IsValidCharacter<T extends string> =
   T extends `${ValidCharacters}${infer Tail}`

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,9 +50,11 @@ export type Filter<
  * type Result = IsNarrowable<'foo', string>
  * //   ^? true
  */
-export type IsNarrowable<T, U> = IsNever<
-  (T extends U ? true : false) & (U extends T ? false : true)
-> extends true
+export type IsNarrowable<T, U> = IsUnknown<T> extends true
+  ? false
+  : IsNever<
+      (T extends U ? true : false) & (U extends T ? false : true)
+    > extends true
   ? false
   : true
 


### PR DESCRIPTION
## Description

Fixes(#174)

This was something that was really unexpected.

So apparently typescript when you pass in a object that is missing a property it will infer it as `unknown` if you try to access it like `Components[K]["name"]`.
And this caused the bug because the `unknown` type is a narrowable type. Meaning that when we do `IsNarrowable<Components[K]["name"], string>` this would resolve as true.
Since unknown extends string and string extends unknown this would cause the condition to pass and then when it would recurse the `components` property would not be of type `AbiParameter[]`, making it fallback to option where it would resolve the param to it's string representation.

The fix that i made was to add a `IsUnknown` check on the `IsNarrowable` type. Something like this will also work.

```ts
(Components[K]['name'] extends undefined
    ? unknown
    : string extends Components[K]['name']
        ? unknown
        : { name: Components[K]['name'] })
```

This PR also adds some validation to the `name` property to ensure that it doesnt contains invalid names.

## Additional Information

- [x] I read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [ ] I added documentation related to the changes made.
- [x] I added or updated tests related to the changes made.

Your ENS/address:

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on improving the human-readable formatting of ABI parameters and fixing bugs related to Solidity keywords and nested tuple types.

### Detailed summary:
- Updated the `FormatAbiParameter` type to handle Solidity keywords correctly.
- Added the `AssertName` type to validate and format ABI parameter names.
- Fixed a bug in `formatAbiParameter` where nested tuple types were not formatted correctly.
- Updated test cases to reflect the changes in formatting.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->