### PR TITLE
fix(eip721): infinite cyclic type

### DIFF
--- a/.changeset/ten-bobcats-beam.md
+++ b/.changeset/ten-bobcats-beam.md
@@ -2,4 +2,4 @@
 "abitype": patch
 ---
 
-Fixed a bug on `TypedDataToPrimativeTypes` where it would create an infinite cyclic type if the `type` was an array type of `keyof TypedData`.
+Fixed a bug on `TypedDataToPrimitiveTypes` where it would create an infinite cyclic type if the `type` was an array type of `keyof TypedData`.

--- a/.changeset/ten-bobcats-beam.md
+++ b/.changeset/ten-bobcats-beam.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+Fixed a bug on `TypedDataToPrimativeTypes` where it would create an infinite cyclic type if the `type` was an array type of `keyof TypedData`.

--- a/src/utils.test-d.ts
+++ b/src/utils.test-d.ts
@@ -834,47 +834,79 @@ test('TypedDataToPrimitiveTypes', () => {
       })
     })
 
-    test('unknown struct', () => {
-      const types = {
-        Name: [
-          { name: 'first', type: 'Foo' },
-          { name: 'last', type: 'string' },
+    const types = {
+      Foo: [{ name: 'bar', type: 'Bar[]' }],
+      Bar: [{ name: 'foo', type: 'Foo' }],
+    } as const
+
+    type Result = TypedDataToPrimitiveTypes<typeof types>
+    assertType<Result>({
+      Foo: {
+        bar: [
+          {
+            foo: {
+              bar: [
+                "Error: Circular reference detected. 'Bar' is a circular reference.",
+              ],
+            },
+          },
         ],
-      } as const
-      type Result = TypedDataToPrimitiveTypes<typeof types>
-      assertType<Result>({
-        Name: {
-          first: [
-            "Error: Cannot convert unknown type 'Foo' to primitive type.",
+      },
+      Bar: {
+        foo: {
+          bar: [
+            {
+              foo: [
+                "Error: Circular reference detected. 'Foo' is a circular reference.",
+              ],
+            },
           ],
-          last: 'Meagher',
         },
-      })
+      },
     })
   })
-})
 
-test('IsTypedData', () => {
-  type Result = IsTypedData<{
-    Person: [
-      { name: 'name'; type: 'string' },
-      { name: 'wallet'; type: 'address' },
-    ]
-    Mail: [
-      { name: 'from'; type: 'Person' },
-      { name: 'to'; type: 'Person' },
-      { name: 'contents'; type: 'string' },
-    ]
-  }>
-  assertType<Result>(true)
+  test('unknown struct', () => {
+    const types = {
+      Name: [
+        { name: 'first', type: 'Foo' },
+        { name: 'last', type: 'string' },
+      ],
+    } as const
+    type Result = TypedDataToPrimitiveTypes<typeof types>
+    assertType<Result>({
+      Name: {
+        first: ["Error: Cannot convert unknown type 'Foo' to primitive type."],
+        last: 'Meagher',
+      },
+    })
+  })
 
-  type Result2 = IsTypedData<{
-    Person: [{ name: 'name'; type: 'string' }, { name: 'wallet'; type: 'Foo' }] // `Foo` does not exist in schema
-    Mail: [
-      { name: 'from'; type: 'Person' },
-      { name: 'to'; type: 'Person' },
-      { name: 'contents'; type: 'string' },
-    ]
-  }>
-  assertType<Result2>(false)
+  test('IsTypedData', () => {
+    type Result = IsTypedData<{
+      Person: [
+        { name: 'name'; type: 'string' },
+        { name: 'wallet'; type: 'address' },
+      ]
+      Mail: [
+        { name: 'from'; type: 'Person' },
+        { name: 'to'; type: 'Person' },
+        { name: 'contents'; type: 'string' },
+      ]
+    }>
+    assertType<Result>(true)
+
+    type Result2 = IsTypedData<{
+      Person: [
+        { name: 'name'; type: 'string' },
+        { name: 'wallet'; type: 'Foo' },
+      ] // `Foo` does not exist in schema
+      Mail: [
+        { name: 'from'; type: 'Person' },
+        { name: 'to'; type: 'Person' },
+        { name: 'contents'; type: 'string' },
+      ]
+    }>
+    assertType<Result2>(false)
+  })
 })

--- a/src/utils.test-d.ts
+++ b/src/utils.test-d.ts
@@ -1,4 +1,4 @@
-import { assertType, test } from 'vitest'
+import { assertType, expectTypeOf, test } from 'vitest'
 
 import type { Abi } from './abi.js'
 import { zeroAddress } from './test.js'
@@ -812,57 +812,68 @@ test('TypedDataToPrimitiveTypes', () => {
         Bar: [{ name: 'foo', type: 'Foo' }],
       } as const
       type Result = TypedDataToPrimitiveTypes<typeof types>
-      assertType<Result>({
-        Foo: {
+      expectTypeOf<Result>().toEqualTypeOf<{
+        readonly Foo: {
           bar: {
-            foo: {
-              bar: [
-                "Error: Circular reference detected. 'Bar' is a circular reference.",
-              ],
-            },
-          },
-        },
-        Bar: {
+            foo: [
+              "Error: Circular reference detected. 'Foo' is a circular reference.",
+            ]
+          }
+        }
+        readonly Bar: {
           foo: {
-            bar: {
+            bar: [
+              "Error: Circular reference detected. 'Bar' is a circular reference.",
+            ]
+          }
+        }
+      }>()
+
+      const types2 = {
+        Foo: [{ name: 'bar', type: 'Bar[]' }],
+        Bar: [{ name: 'foo', type: 'Foo' }],
+      } as const
+      type Result2 = TypedDataToPrimitiveTypes<typeof types2>
+      expectTypeOf<Result2>().toEqualTypeOf<{
+        readonly Foo: {
+          bar: readonly {
+            foo: [
+              "Error: Circular reference detected. 'Foo' is a circular reference.",
+            ]
+          }[]
+        }
+        readonly Bar: {
+          foo: {
+            bar: readonly {
               foo: [
                 "Error: Circular reference detected. 'Foo' is a circular reference.",
-              ],
-            },
-          },
-        },
-      })
-    })
+              ]
+            }[]
+          }
+        }
+      }>()
 
-    const types = {
-      Foo: [{ name: 'bar', type: 'Bar[]' }],
-      Bar: [{ name: 'foo', type: 'Foo' }],
-    } as const
-
-    type Result = TypedDataToPrimitiveTypes<typeof types>
-    assertType<Result>({
-      Foo: {
-        bar: [
-          {
-            foo: {
-              bar: [
-                "Error: Circular reference detected. 'Bar' is a circular reference.",
-              ],
-            },
-          },
-        ],
-      },
-      Bar: {
-        foo: {
-          bar: [
-            {
-              foo: [
-                "Error: Circular reference detected. 'Foo' is a circular reference.",
-              ],
-            },
-          ],
-        },
-      },
+      const types3 = {
+        Foo: [{ name: 'bar', type: 'Bar[]' }],
+        Bar: [{ name: 'foo', type: 'Foo[]' }],
+      } as const
+      type Result3 = TypedDataToPrimitiveTypes<typeof types3>
+      expectTypeOf<Result3>().toEqualTypeOf<{
+        readonly Foo: {
+          bar: readonly {
+            foo: readonly [
+              "Error: Circular reference detected. 'Foo[]' is a circular reference.",
+            ][]
+          }[]
+        }
+        readonly Bar: {
+          foo: readonly {
+            bar: readonly [
+              "Error: Circular reference detected. 'Bar[]' is a circular reference.",
+            ][]
+          }[]
+        }
+      }>()
     })
   })
 


### PR DESCRIPTION
## Description

Meant to do this one earlier.

While working on (#166) noticed that if we pass a array type like `Foo[]` it would create an infinite cyclic type.
This PR aims to fix that.

## Additional Information

- [x] I read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [ ] I added documentation related to the changes made.
- [x] I added or updated tests related to the changes made.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug in the `TypedDataToPrimitiveTypes` function related to cyclic types. 

### Detailed summary
- Fixed a bug where `TypedDataToPrimitiveTypes` would create an infinite cyclic type.
- Added error handling for circular references in struct types.
- Improved type checking and conversion in `TypedDataToPrimitiveTypes`.
- Added test cases for the fixed bug and type checking.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->