### PR TITLE
refactor: error on recursive types earlier

### DIFF
--- a/src/utils.test-d.ts
+++ b/src/utils.test-d.ts
@@ -1,4 +1,4 @@
-import { assertType, test } from 'vitest'
+import { assertType, expectTypeOf, test } from 'vitest'
 
 import type { Abi } from './abi.js'
 import { zeroAddress } from './test.js'
@@ -812,57 +812,68 @@ test('TypedDataToPrimitiveTypes', () => {
         Bar: [{ name: 'foo', type: 'Foo' }],
       } as const
       type Result = TypedDataToPrimitiveTypes<typeof types>
-      assertType<Result>({
-        Foo: {
+      expectTypeOf<Result>().toEqualTypeOf<{
+        readonly Foo: {
           bar: {
-            foo: {
-              bar: [
-                "Error: Circular reference detected. 'Bar' is a circular reference.",
-              ],
-            },
-          },
-        },
-        Bar: {
+            foo: [
+              "Error: Circular reference detected. 'Foo' is a circular reference.",
+            ]
+          }
+        }
+        readonly Bar: {
           foo: {
-            bar: {
+            bar: [
+              "Error: Circular reference detected. 'Bar' is a circular reference.",
+            ]
+          }
+        }
+      }>()
+
+      const types2 = {
+        Foo: [{ name: 'bar', type: 'Bar[]' }],
+        Bar: [{ name: 'foo', type: 'Foo' }],
+      } as const
+      type Result2 = TypedDataToPrimitiveTypes<typeof types2>
+      expectTypeOf<Result2>().toEqualTypeOf<{
+        readonly Foo: {
+          bar: readonly {
+            foo: [
+              "Error: Circular reference detected. 'Foo' is a circular reference.",
+            ]
+          }[]
+        }
+        readonly Bar: {
+          foo: {
+            bar: readonly {
               foo: [
                 "Error: Circular reference detected. 'Foo' is a circular reference.",
-              ],
-            },
-          },
-        },
-      })
-    })
+              ]
+            }[]
+          }
+        }
+      }>()
 
-    const types = {
-      Foo: [{ name: 'bar', type: 'Bar[]' }],
-      Bar: [{ name: 'foo', type: 'Foo' }],
-    } as const
-
-    type Result = TypedDataToPrimitiveTypes<typeof types>
-    assertType<Result>({
-      Foo: {
-        bar: [
-          {
-            foo: {
-              bar: [
-                "Error: Circular reference detected. 'Bar' is a circular reference.",
-              ],
-            },
-          },
-        ],
-      },
-      Bar: {
-        foo: {
-          bar: [
-            {
-              foo: [
-                "Error: Circular reference detected. 'Foo' is a circular reference.",
-              ],
-            },
-          ],
-        },
-      },
+      const types3 = {
+        Foo: [{ name: 'bar', type: 'Bar[]' }],
+        Bar: [{ name: 'foo', type: 'Foo[]' }],
+      } as const
+      type Result3 = TypedDataToPrimitiveTypes<typeof types3>
+      expectTypeOf<Result3>().toEqualTypeOf<{
+        readonly Foo: {
+          bar: readonly {
+            foo: readonly [
+              "Error: Circular reference detected. 'Foo[]' is a circular reference.",
+            ][]
+          }[]
+        }
+        readonly Bar: {
+          foo: readonly {
+            bar: readonly [
+              "Error: Circular reference detected. 'Bar[]' is a circular reference.",
+            ][]
+          }[]
+        }
+      }>()
     })
   })
 


### PR DESCRIPTION
## Description

Small refactor to error out earlier

## Additional Information

- [x] I read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [ ] I added documentation related to the changes made.
- [x] I added or updated tests related to the changes made.

Your ENS/address: awkweb.eth


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Fixing circular reference errors in the `TypedDataToPrimitiveTypes` function.

### Detailed summary:
- Updated the `TypedDataToPrimitiveTypes` function to handle circular references correctly.
- Added error handling for circular references in struct and array types.
- Improved type checking for tuple components.
- Updated test cases to reflect the changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->