### PR TITLE
fix(zod): allow empty name in AbiParameter

### DIFF
--- a/.changeset/large-pugs-add.md
+++ b/.changeset/large-pugs-add.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+Fix a bug that empty string name in AbiParameter isn't allowed.

--- a/.changeset/large-pugs-add.md
+++ b/.changeset/large-pugs-add.md
@@ -2,4 +2,4 @@
 "abitype": patch
 ---
 
-Fix a bug that empty string name in AbiParameter isn't allowed.
+Fixed a bug where an empty string on the `name` property in AbiParameter wasn't allowed.

--- a/src/zod.test.ts
+++ b/src/zod.test.ts
@@ -611,10 +611,12 @@ describe('AbiParameter', () => {
   it('returns valid schema', () => {
     expect(
       AbiParameter.parse({
+        name: '',
         type: 'address',
       }),
     ).toMatchInlineSnapshot(`
       {
+        "name": "",
         "type": "address",
       }
     `)

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -52,7 +52,7 @@ export const SolidityArray = z.union([
 export const AbiParameter: z.ZodType<AbiParameterType> = z.lazy(() =>
   z.intersection(
     z.object({
-      name: Identifier.optional(),
+      name: z.union([Identifier.optional(), z.literal('')]),
       /** Representation used by Solidity compiler */
       internalType: z.string().optional(),
     }),


### PR DESCRIPTION
## Description

Please refer to Issue #184.

## Additional Information

- [x] I read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [x] I added documentation related to the changes made.
- [x] I added or updated tests related to the changes made.

Your ENS/address:

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Fixed a bug where an empty string on the `name` property in AbiParameter wasn't allowed.
- Updated the `name` property in `z.object` to accept either an `Identifier` or an empty string.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->