### PR TITLE
feat: add unknown to Narrow

### DIFF
--- a/.changeset/nice-shirts-punch.md
+++ b/.changeset/nice-shirts-punch.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+Added `unknown` support to `Narrow`

--- a/rome.json
+++ b/rome.json
@@ -19,9 +19,6 @@
     "enabled": true,
     "rules": {
       "recommended": true,
-      "complexity": {
-        "noExtraSemicolon": "off"
-      },
       "correctness": {
         "noUnusedVariables": "error"
       },

--- a/src/narrow.test-d.ts
+++ b/src/narrow.test-d.ts
@@ -1,17 +1,18 @@
-import { assertType, test } from 'vitest'
+import { assertType, expectTypeOf, test } from 'vitest'
 
 import type { Narrow } from './narrow.js'
 import { narrow } from './narrow.js'
 
 test('Narrow', () => {
-  assertType<Narrow<['foo', 'bar', 1]>>(['foo', 'bar', 1])
+  expectTypeOf<Narrow<['foo', 'bar', 1]>>().toEqualTypeOf<['foo', 'bar', 1]>()
+  expectTypeOf<Narrow<unknown>>().toEqualTypeOf<unknown>()
 })
 
 test('narrow', () => {
   const asConst = narrow(['foo', 'bar', 1])
   //    ^?
   type Result = typeof asConst
-  assertType<Result>(['foo', 'bar', 1])
+  expectTypeOf<Result>().toEqualTypeOf<['foo', 'bar', 1]>()
 
   assertType<'foo'>(narrow('foo'))
   assertType<1>(narrow(1))

--- a/src/narrow.ts
+++ b/src/narrow.ts
@@ -9,12 +9,11 @@
  */
 // s/o https://twitter.com/hd_nvim/status/1578567206190780417
 export type Narrow<TType> =
+  | (unknown extends TType ? unknown : never)
   | (TType extends Function ? TType : never)
-  | (TType extends string | number | boolean | bigint ? TType : never)
+  | (TType extends bigint | boolean | number | string ? TType : never)
   | (TType extends [] ? [] : never)
-  | {
-      [K in keyof TType]: Narrow<TType[K]>
-    }
+  | { [K in keyof TType]: Narrow<TType[K]> }
 
 /**
  * Infers embedded primitive type of any type


### PR DESCRIPTION
## Description

Adds `unknown` support to `Narrow<...>`

## Additional Information

- [x] I read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [x] I added documentation related to the changes made.
- [x] I added or updated tests related to the changes made.

Your ENS/address: awkweb.eth


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Patch to add support for `unknown` type in the `Narrow` function.

### Detailed summary:
- Added `unknown` support to the `Narrow` function in `src/narrow.ts`
- Updated the `Narrow` type definition to include `unknown` in the union type
- Added tests for `Narrow` function in `src/narrow.test-d.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->