### PR TITLE
fix: fixes zod parsed abi's assignability to `Abi`

### DIFF
--- a/.changeset/chilled-buckets-dance.md
+++ b/.changeset/chilled-buckets-dance.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+Fixed an issue where zod parsed abi's where not assignable to `Abi` type.

--- a/.changeset/chilled-buckets-dance.md
+++ b/.changeset/chilled-buckets-dance.md
@@ -2,4 +2,4 @@
 "abitype": patch
 ---
 
-Fixed an issue where zod parsed abi's where not assignable to `Abi` type.
+Fixed an issue where Zod's parsed ABIs where not assignable to the `Abi` type.

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "bench": "vitest bench",
     "build": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm && pnpm run build:types",
-    "build:cjs": "tsc --project tsconfig.build.json --module commonjs --moduleResolution node16 --outDir ./dist/cjs --removeComments --verbatimModuleSyntax false && echo > ./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.build.json --module es2015 --moduleResolution node16 --outDir ./dist/esm --removeComments && echo > ./dist/esm/package.json '{\"type\":\"module\",\"sideEffects\":false}'",
+    "build:cjs": "tsc --project tsconfig.build.json --module commonjs --moduleResolution node10 --outDir ./dist/cjs --removeComments --verbatimModuleSyntax false && echo > ./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --moduleResolution node10 --outDir ./dist/esm --removeComments && echo > ./dist/esm/package.json '{\"type\":\"module\",\"sideEffects\":false}'",
     "build:types": "tsc --project tsconfig.build.json --declarationDir ./dist/types --emitDeclarationOnly --declaration --declarationMap",
     "changeset": "changeset",
     "changeset:release": "pnpm build && changeset publish",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "bench": "vitest bench",
     "build": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm && pnpm run build:types",
-    "build:cjs": "tsc --project tsconfig.build.json --module commonjs --moduleResolution node10 --outDir ./dist/cjs --removeComments --verbatimModuleSyntax false && echo > ./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.build.json --module es2015 --moduleResolution node10 --outDir ./dist/esm --removeComments && echo > ./dist/esm/package.json '{\"type\":\"module\",\"sideEffects\":false}'",
+    "build:cjs": "tsc --project tsconfig.build.json --module commonjs --moduleResolution node16 --outDir ./dist/cjs --removeComments --verbatimModuleSyntax false && echo > ./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --moduleResolution node16 --outDir ./dist/esm --removeComments && echo > ./dist/esm/package.json '{\"type\":\"module\",\"sideEffects\":false}'",
     "build:types": "tsc --project tsconfig.build.json --declarationDir ./dist/types --emitDeclarationOnly --declaration --declarationMap",
     "changeset": "changeset",
     "changeset:release": "pnpm build && changeset publish",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "scripts": {
     "bench": "vitest bench",
     "build": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm && pnpm run build:types",
-    "build:cjs": "tsc --project tsconfig.build.json --module commonjs --outDir ./dist/cjs --removeComments --verbatimModuleSyntax false && echo > ./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir ./dist/esm --removeComments && echo > ./dist/esm/package.json '{\"type\":\"module\",\"sideEffects\":false}'",
-    "build:types": "tsc --project tsconfig.build.json --module esnext --declarationDir ./dist/types --emitDeclarationOnly --declaration --declarationMap",
+    "build:cjs": "tsc --project tsconfig.build.json --module commonjs --moduleResolution node10 --outDir ./dist/cjs --removeComments --verbatimModuleSyntax false && echo > ./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --moduleResolution node10 --outDir ./dist/esm --removeComments && echo > ./dist/esm/package.json '{\"type\":\"module\",\"sideEffects\":false}'",
+    "build:types": "tsc --project tsconfig.build.json --declarationDir ./dist/types --emitDeclarationOnly --declaration --declarationMap",
     "changeset": "changeset",
     "changeset:release": "pnpm build && changeset publish",
     "changeset:version": "changeset version && pnpm install --lockfile-only && pnpm bun scripts/updateVersion.ts",
@@ -70,15 +70,9 @@
   },
   "typesVersions": {
     "*": {
-      "config": [
-        "./dist/types/config.d.ts"
-      ],
-      "test": [
-        "./dist/types/test.d.ts"
-      ],
-      "zod": [
-        "./dist/types/zod.d.ts"
-      ]
+      "config": ["./dist/types/config.d.ts"],
+      "test": ["./dist/types/test.d.ts"],
+      "zod": ["./dist/types/zod.d.ts"]
     }
   },
   "peerDependencies": {
@@ -111,23 +105,14 @@
     "vitest": "^0.30.1",
     "zod": "^3.20.6"
   },
-  "contributors": [
-    "jxom.eth <j@wagmi.sh>",
-    "awkweb.eth <t@wagmi.sh>"
-  ],
+  "contributors": ["jxom.eth <j@wagmi.sh>", "awkweb.eth <t@wagmi.sh>"],
   "funding": [
     {
       "type": "github",
       "url": "https://github.com/sponsors/wagmi-dev"
     }
   ],
-  "keywords": [
-    "abi",
-    "eth",
-    "ethereum",
-    "typescript",
-    "web3"
-  ],
+  "keywords": ["abi", "eth", "ethereum", "typescript", "web3"],
   "simple-git-hooks": {
     "pre-commit": "pnpm format && pnpm lint:fix"
   },
@@ -138,9 +123,7 @@
       "shiki-twoslash>shiki": "^0.14.1"
     },
     "peerDependencyRules": {
-      "ignoreMissing": [
-        "@algolia/client-search"
-      ]
+      "ignoreMissing": ["@algolia/client-search"]
     }
   }
 }

--- a/src/zod.test-d.ts
+++ b/src/zod.test-d.ts
@@ -1,13 +1,17 @@
-import type { Abi as AbiType } from './abi.js'
-import { Abi } from './zod.js'
+import type { Abi } from './abi.js'
+import { Abi as AbiSchema } from './zod.js'
 import { describe, expectTypeOf, test } from 'vitest'
 
 describe('Zod Types', () => {
   test('assignable to Abi', () => {
-    const parsed: AbiType = Abi.parse([])
+    const parsed: Abi = AbiSchema.parse([])
+    type Result = typeof parsed extends Abi ? true : false
+    expectTypeOf<Result>().toEqualTypeOf<true>()
+  })
 
-    type ZodParse = typeof parsed extends AbiType ? true : false
-
-    expectTypeOf<ZodParse>().toEqualTypeOf<true>()
+  test('extends Abi', () => {
+    const parsed = AbiSchema.parse([])
+    type Result = typeof parsed extends Abi ? true : false
+    expectTypeOf<Result>().toEqualTypeOf<true>()
   })
 })

--- a/src/zod.test-d.ts
+++ b/src/zod.test-d.ts
@@ -1,0 +1,13 @@
+import type { Abi as AbiType } from './abi.js'
+import { Abi } from './zod.js'
+import { describe, expectTypeOf, test } from 'vitest'
+
+describe('Zod Types', () => {
+  test('assignable to Abi', () => {
+    const parsed: AbiType = Abi.parse([])
+
+    type ZodParse = typeof parsed extends AbiType ? true : false
+
+    expectTypeOf<ZodParse>().toEqualTypeOf<true>()
+  })
+})

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 import type {
   AbiConstructor as AbiConstructorType,
+  AbiEventParameter as AbiEventParameterType,
   AbiFallback as AbiFallbackType,
   AbiFunction as AbiFunctionType,
   AbiParameter as AbiParameterType,
@@ -76,10 +77,8 @@ export const AbiParameter: z.ZodType<AbiParameterType> = z.lazy(() =>
   ),
 )
 
-export const AbiEventParameter = z.intersection(
-  AbiParameter,
-  z.object({ indexed: z.boolean().optional() }),
-)
+export const AbiEventParameter: z.ZodType<AbiEventParameterType> =
+  z.intersection(AbiParameter, z.object({ indexed: z.boolean().optional() }))
 
 export const AbiStateMutability = z.union([
   z.literal('pure'),
@@ -260,7 +259,6 @@ export const Abi = z.array(
            * https://github.com/ethereum/solidity/issues/992
            */
           payable: z.boolean().optional(),
-          stateMutability: AbiStateMutability,
         }),
         z.discriminatedUnion('type', [
           z.object({
@@ -268,14 +266,23 @@ export const Abi = z.array(
             inputs: z.array(AbiParameter),
             name: z.string().regex(/[a-zA-Z$_][a-zA-Z0-9$_]*/),
             outputs: z.array(AbiParameter),
+            stateMutability: AbiStateMutability,
           }),
           z.object({
             type: z.literal('constructor'),
             inputs: z.array(AbiParameter),
+            stateMutability: z.union([
+              z.literal('payable'),
+              z.literal('nonpayable'),
+            ]),
           }),
           z.object({
             type: z.literal('fallback'),
             inputs: z.tuple([]).optional(),
+            stateMutability: z.union([
+              z.literal('payable'),
+              z.literal('nonpayable'),
+            ]),
           }),
           z.object({
             type: z.literal('receive'),

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -28,7 +28,7 @@
 
     // Language and environment
     "moduleResolution": "NodeNext",
-    "module": "ESNext",
+    "module": "NodeNext",
     "target": "ES2021", // Setting this to `ES2021` enables native support for `Node v16+`: https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping.
     "lib": [
       "ES2022", // By using ES2022 we get access to the `.cause` property on `Error` instances.


### PR DESCRIPTION
## Description

Fixes (#189)

## Additional Information

- [x] I read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [ ] I added documentation related to the changes made.
- [x] I added or updated tests related to the changes made.

Your ENS/address:

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue with Zod's parsed ABIs not being assignable to the `Abi` type. 

### Detailed summary
- Fixed the issue where Zod's parsed ABIs were not assignable to the `Abi` type.
- Updated the `module` setting in `tsconfig.base.json` to "NodeNext".
- Added new tests in `zod.test-d.ts` to ensure Zod types are assignable to `Abi`.
- Updated the `AbiEventParameter` type in `zod.ts` to include the `stateMutability` property.
- Updated the build scripts in `package.json` to use the `--moduleResolution node10` flag.
- Updated the `typesVersions` field in `package.json` to include specific paths for types.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->