### PR TITLE
fix: change `zod` schemas inputs/outputs to `readonly` to match abitype

### DIFF
--- a/.changeset/seven-planes-deliver.md
+++ b/.changeset/seven-planes-deliver.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+Changed AbiEvent.inputs to readonly to match AbiEvent type

--- a/.changeset/seven-planes-deliver.md
+++ b/.changeset/seven-planes-deliver.md
@@ -2,4 +2,9 @@
 "abitype": patch
 ---
 
-Changed AbiEvent.inputs to readonly to match AbiEvent type
+Changed the following types to readonly in zod package:
+
+- `AbiContructor.inputs`
+- `AbiError.inputs`
+- `AbiEvent.inputs`
+- `AbiFunction.inputs` / `AbiFunction.outputs`

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -95,6 +95,8 @@ pnpm test
 pnpm test:typecheck
 ```
 
+Note: ensure to build the package (`pnpm build`) before running the `test:typecheck` suite.
+
 <div align="right">
   <a href="#basic-guide">&uarr; back to top</a></b>
 </div>

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -54,13 +54,14 @@ gh repo clone wagmi-dev/abitype
 
 ## Installing Node.js and pnpm
 
-ABIType uses [pnpm](https://pnpm.io) as its package manager. You need to install **Node.js v16 or higher** and **pnpm v7 or higher**.
+ABIType uses [pnpm](https://pnpm.io) as its package manager. You need to install **Node.js v16 or higher**, **pnpm exactly v8.3.1** and **TyepScript exactly v5.0.4**.
 
 You can run the following commands in your terminal to check your local Node.js and npm versions:
 
 ```bash
 node -v
 pnpm -v
+pnpm tsc -v
 ```
 
 If the versions are not correct or you don't have Node.js or pnpm installed, download and follow their setup instructions:
@@ -95,7 +96,7 @@ pnpm test
 pnpm test:typecheck
 ```
 
-Note: ensure to build the package (`pnpm build`) before running the `test:typecheck` suite.
+> **Note** Ensure to build the package (`pnpm build`) before running the `test:typecheck` suite.
 
 <div align="right">
   <a href="#basic-guide">&uarr; back to top</a></b>

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -54,14 +54,13 @@ gh repo clone wagmi-dev/abitype
 
 ## Installing Node.js and pnpm
 
-ABIType uses [pnpm](https://pnpm.io) as its package manager. You need to install **Node.js v16 or higher**, **pnpm exactly v8.3.1** and **TypeScript exactly v5.0.4**.
+ABIType uses [pnpm](https://pnpm.io) as its package manager. You need to install **Node.js v16 or higher** and **pnpm v7 or higher**.
 
 You can run the following commands in your terminal to check your local Node.js and npm versions:
 
 ```bash
 node -v
 pnpm -v
-pnpm tsc -v
 ```
 
 If the versions are not correct or you don't have Node.js or pnpm installed, download and follow their setup instructions:
@@ -82,6 +81,8 @@ pnpm install
 ```
 
 After the install completes, pnpm links packages across the project for development and [git hooks](https://github.com/toplenboren/simple-git-hooks) are set up.
+
+> **Note:** In case you have to install new packages or upgrade packages make sure to use **pnpm@8.3.1** and **typescript@5.0.4**
 
 <div align="right">
   <a href="#basic-guide">&uarr; back to top</a></b>

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -54,7 +54,7 @@ gh repo clone wagmi-dev/abitype
 
 ## Installing Node.js and pnpm
 
-ABIType uses [pnpm](https://pnpm.io) as its package manager. You need to install **Node.js v16 or higher**, **pnpm exactly v8.3.1** and **TyepScript exactly v5.0.4**.
+ABIType uses [pnpm](https://pnpm.io) as its package manager. You need to install **Node.js v16 or higher**, **pnpm exactly v8.3.1** and **TypeScript exactly v5.0.4**.
 
 You can run the following commands in your terminal to check your local Node.js and npm versions:
 

--- a/package.json
+++ b/package.json
@@ -70,15 +70,9 @@
   },
   "typesVersions": {
     "*": {
-      "config": [
-        "./dist/types/config.d.ts"
-      ],
-      "test": [
-        "./dist/types/test.d.ts"
-      ],
-      "zod": [
-        "./dist/types/zod.d.ts"
-      ]
+      "config": ["./dist/types/config.d.ts"],
+      "test": ["./dist/types/test.d.ts"],
+      "zod": ["./dist/types/zod.d.ts"]
     }
   },
   "peerDependencies": {
@@ -111,23 +105,14 @@
     "vitest": "^0.30.1",
     "zod": "^3.22.4"
   },
-  "contributors": [
-    "jxom.eth <j@wagmi.sh>",
-    "awkweb.eth <t@wagmi.sh>"
-  ],
+  "contributors": ["jxom.eth <j@wagmi.sh>", "awkweb.eth <t@wagmi.sh>"],
   "funding": [
     {
       "type": "github",
       "url": "https://github.com/sponsors/wagmi-dev"
     }
   ],
-  "keywords": [
-    "abi",
-    "eth",
-    "ethereum",
-    "typescript",
-    "web3"
-  ],
+  "keywords": ["abi", "eth", "ethereum", "typescript", "web3"],
   "simple-git-hooks": {
     "pre-commit": "pnpm format && pnpm lint:fix"
   },
@@ -138,9 +123,7 @@
       "shiki-twoslash>shiki": "^0.14.1"
     },
     "peerDependencyRules": {
-      "ignoreMissing": [
-        "@algolia/client-search"
-      ]
+      "ignoreMissing": ["@algolia/client-search"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "peerDependencies": {
     "typescript": ">=5.0.4",
-    "zod": "^3 >=3.19.1"
+    "zod": "^3 >=3.22.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "typescript": "5.0.4",
     "typescript@5.1.3": "npm:typescript@5.1.3",
     "vitest": "^0.30.1",
-    "zod": "^3.20.6"
+    "zod": "^3.22.4"
   },
   "contributors": [
     "jxom.eth <j@wagmi.sh>",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   remark-shiki-twoslash>shiki: ^0.14.1
   shiki-twoslash>shiki: ^0.14.1
@@ -54,8 +58,8 @@ importers:
         specifier: ^0.30.1
         version: 0.30.1
       zod:
-        specifier: ^3.20.6
-        version: 3.21.4
+        specifier: ^3.22.4
+        version: 3.22.4
 
   docs:
     devDependencies:
@@ -76,10 +80,10 @@ importers:
         version: 3.0.3
       vitepress:
         specifier: 1.0.0-beta.1
-        version: 1.0.0-beta.1(@types/node@18.16.3)(search-insights@2.6.0)
+        version: 1.0.0-beta.1(@types/node@18.16.3)(search-insights@2.8.3)
       vitepress-plugin-shiki-twoslash:
         specifier: 0.0.6
-        version: 0.0.6(typescript@5.0.4)(vitepress@1.0.0-beta.1)
+        version: 0.0.6(typescript@5.2.2)(vitepress@1.0.0-beta.1)
       vue:
         specifier: ^3.3.4
         version: 3.3.4
@@ -102,10 +106,10 @@ packages:
     resolution: {integrity: sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==}
     dev: true
 
-  /@algolia/autocomplete-core@1.9.2(algoliasearch@4.17.0)(search-insights@2.6.0):
+  /@algolia/autocomplete-core@1.9.2(algoliasearch@4.17.0)(search-insights@2.8.3):
     resolution: {integrity: sha512-hkG80c9kx9ClVAEcUJbTd2ziVC713x9Bji9Ty4XJfKXlxlsx3iXsoNhAwfeR4ulzIUg7OE5gez0UU1zVDdG7kg==}
     dependencies:
-      '@algolia/autocomplete-plugin-algolia-insights': 1.9.2(algoliasearch@4.17.0)(search-insights@2.6.0)
+      '@algolia/autocomplete-plugin-algolia-insights': 1.9.2(algoliasearch@4.17.0)(search-insights@2.8.3)
       '@algolia/autocomplete-shared': 1.9.2(algoliasearch@4.17.0)
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -113,13 +117,13 @@ packages:
       - search-insights
     dev: true
 
-  /@algolia/autocomplete-plugin-algolia-insights@1.9.2(algoliasearch@4.17.0)(search-insights@2.6.0):
+  /@algolia/autocomplete-plugin-algolia-insights@1.9.2(algoliasearch@4.17.0)(search-insights@2.8.3):
     resolution: {integrity: sha512-2LVsf4W66hVHQ3Ua/8k15oPlxjELCztbAkQm/hP42Sw+GLkHAdY1vaVRYziaWq64+Oljfg6FKkZHCdgXH+CGIA==}
     peerDependencies:
       search-insights: '>= 1 < 3'
     dependencies:
       '@algolia/autocomplete-shared': 1.9.2(algoliasearch@4.17.0)
-      search-insights: 2.6.0
+      search-insights: 2.8.3
     transitivePeerDependencies:
       - '@algolia/client-search'
       - algoliasearch
@@ -506,10 +510,10 @@ packages:
     resolution: {integrity: sha512-Ob5FQLubplcBNihAVtriR59FRBeP8u69F6mu4L4yIr60KfsPc10bOV0DoPErJw0zF9IBN2cNLW9qdmt8zWPxyg==}
     dev: true
 
-  /@docsearch/js@3.5.0(search-insights@2.6.0):
+  /@docsearch/js@3.5.0(search-insights@2.8.3):
     resolution: {integrity: sha512-WqB+z+zVKSXDkGq028nClT9RvMzfFlemZuIulX5ZwWkdUtl4k7M9cmZA/c6kuZf7FG24XQsMHWuBjeUo9hLRyA==}
     dependencies:
-      '@docsearch/react': 3.5.0(search-insights@2.6.0)
+      '@docsearch/react': 3.5.0(search-insights@2.8.3)
       preact: 10.13.2
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -519,7 +523,7 @@ packages:
       - search-insights
     dev: true
 
-  /@docsearch/react@3.5.0(search-insights@2.6.0):
+  /@docsearch/react@3.5.0(search-insights@2.8.3):
     resolution: {integrity: sha512-3IG8mmSMzSHNGy2S1VuPyYU9tFCxFpj5Ov8SYwsSHM4yMvFsaO9oFxXocA5lSenliIELhuOuS5+BdxHa/Qlf2A==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 19.0.0'
@@ -533,7 +537,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@algolia/autocomplete-core': 1.9.2(algoliasearch@4.17.0)(search-insights@2.6.0)
+      '@algolia/autocomplete-core': 1.9.2(algoliasearch@4.17.0)(search-insights@2.8.3)
       '@algolia/autocomplete-preset-algolia': 1.9.2(algoliasearch@4.17.0)
       '@docsearch/css': 3.5.0
       algoliasearch: 4.17.0
@@ -2192,8 +2196,8 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -3162,7 +3166,7 @@ packages:
       functions-have-names: 1.2.3
     dev: true
 
-  /remark-shiki-twoslash@3.1.3(typescript@5.0.4):
+  /remark-shiki-twoslash@3.1.3(typescript@5.2.2):
     resolution: {integrity: sha512-4e8OH3ySOCw5wUbDcPszokOKjKuebOqlP2WlySvC7ITBOq27BiGsFlq+FNWhxppZ+JzhTWah4gQrnMjX3KDbAQ==}
     peerDependencies:
       typescript: '>3'
@@ -3173,9 +3177,9 @@ packages:
       fenceparser: 1.1.1
       regenerator-runtime: 0.13.11
       shiki: 0.14.1
-      shiki-twoslash: 3.1.2(typescript@5.0.4)
+      shiki-twoslash: 3.1.2(typescript@5.2.2)
       tslib: 2.1.0
-      typescript: 5.0.4
+      typescript: 5.2.2
       unist-util-visit: 2.0.3
     transitivePeerDependencies:
       - supports-color
@@ -3229,7 +3233,7 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /rome@12.1.3:
@@ -3264,9 +3268,8 @@ packages:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: true
 
-  /search-insights@2.6.0:
-    resolution: {integrity: sha512-vU2/fJ+h/Mkm/DJOe+EaM5cafJv/1rRTZpGJTuFPf/Q5LjzgMDsqPdSaZsAe+GAWHHsfsu+rQSAn6c8IGtBEVw==}
-    engines: {node: '>=8.16.0'}
+  /search-insights@2.8.3:
+    resolution: {integrity: sha512-W9rZfQ9XEfF0O6ntgQOTI7Txc8nkZrO4eJ/pTHK0Br6wWND2sPGPoWg+yGhdIW7wMbLqk8dc23IyEtLlNGpeNw==}
     dev: true
 
   /semver@5.7.1:
@@ -3315,7 +3318,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /shiki-twoslash@3.1.2(typescript@5.0.4):
+  /shiki-twoslash@3.1.2(typescript@5.2.2):
     resolution: {integrity: sha512-JBcRIIizi+exIA/OUhYkV6jtyeZco0ykCkIRd5sgwIt1Pm4pz+maoaRZpm6SkhPwvif4fCA7xOtJOykhpIV64Q==}
     peerDependencies:
       typescript: '>3'
@@ -3324,7 +3327,7 @@ packages:
       '@typescript/vfs': 1.3.4
       fenceparser: 1.1.1
       shiki: 0.14.1
-      typescript: 5.0.4
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3670,6 +3673,12 @@ packages:
     hasBin: true
     dev: true
 
+  /typescript@5.2.2:
+    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
+
   /ufo@1.1.1:
     resolution: {integrity: sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==}
     dev: true
@@ -3779,7 +3788,7 @@ packages:
       postcss: 8.4.23
       rollup: 3.21.2
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /vite@4.3.9(@types/node@18.16.3):
@@ -3812,27 +3821,27 @@ packages:
       postcss: 8.4.24
       rollup: 3.21.2
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
-  /vitepress-plugin-shiki-twoslash@0.0.6(typescript@5.0.4)(vitepress@1.0.0-beta.1):
+  /vitepress-plugin-shiki-twoslash@0.0.6(typescript@5.2.2)(vitepress@1.0.0-beta.1):
     resolution: {integrity: sha512-CjMF01Vb/zwOKKCqq6QmkJbTJnRxipv8oiPjRWTjzH2jPaQH4gGCF2fZHS7uY53J3gbU3GwtrXI02J6axLYmbg==}
     peerDependencies:
       vitepress: '>=1.0.0-alpha.61'
     dependencies:
-      remark-shiki-twoslash: 3.1.3(typescript@5.0.4)
-      vitepress: 1.0.0-beta.1(@types/node@18.16.3)(search-insights@2.6.0)
+      remark-shiki-twoslash: 3.1.3(typescript@5.2.2)
+      vitepress: 1.0.0-beta.1(@types/node@18.16.3)(search-insights@2.8.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /vitepress@1.0.0-beta.1(@types/node@18.16.3)(search-insights@2.6.0):
+  /vitepress@1.0.0-beta.1(@types/node@18.16.3)(search-insights@2.8.3):
     resolution: {integrity: sha512-V2yyCwQ+v9fh7rbnGDLp8M7vHa9sLElexXf/JHtBOsOwv7ed9wt1QI4WUagYgKR3TeoJT9v2s6f0UaQSne0EvQ==}
     hasBin: true
     dependencies:
       '@docsearch/css': 3.5.0
-      '@docsearch/js': 3.5.0(search-insights@2.6.0)
+      '@docsearch/js': 3.5.0(search-insights@2.8.3)
       '@vitejs/plugin-vue': 4.2.3(vite@4.3.9)(vue@3.3.4)
       '@vue/devtools-api': 6.5.0
       '@vueuse/core': 10.1.2(vue@3.3.4)
@@ -4181,6 +4190,6 @@ packages:
     engines: {node: '>=12.20'}
     dev: true
 
-  /zod@3.21.4:
-    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 overrides:
   remark-shiki-twoslash>shiki: ^0.14.1
   shiki-twoslash>shiki: ^0.14.1
@@ -80,10 +76,10 @@ importers:
         version: 3.0.3
       vitepress:
         specifier: 1.0.0-beta.1
-        version: 1.0.0-beta.1(@types/node@18.16.3)(search-insights@2.8.3)
+        version: 1.0.0-beta.1(@types/node@18.16.3)(search-insights@2.6.0)
       vitepress-plugin-shiki-twoslash:
         specifier: 0.0.6
-        version: 0.0.6(typescript@5.2.2)(vitepress@1.0.0-beta.1)
+        version: 0.0.6(typescript@5.0.4)(vitepress@1.0.0-beta.1)
       vue:
         specifier: ^3.3.4
         version: 3.3.4
@@ -106,10 +102,10 @@ packages:
     resolution: {integrity: sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==}
     dev: true
 
-  /@algolia/autocomplete-core@1.9.2(algoliasearch@4.17.0)(search-insights@2.8.3):
+  /@algolia/autocomplete-core@1.9.2(algoliasearch@4.17.0)(search-insights@2.6.0):
     resolution: {integrity: sha512-hkG80c9kx9ClVAEcUJbTd2ziVC713x9Bji9Ty4XJfKXlxlsx3iXsoNhAwfeR4ulzIUg7OE5gez0UU1zVDdG7kg==}
     dependencies:
-      '@algolia/autocomplete-plugin-algolia-insights': 1.9.2(algoliasearch@4.17.0)(search-insights@2.8.3)
+      '@algolia/autocomplete-plugin-algolia-insights': 1.9.2(algoliasearch@4.17.0)(search-insights@2.6.0)
       '@algolia/autocomplete-shared': 1.9.2(algoliasearch@4.17.0)
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -117,13 +113,13 @@ packages:
       - search-insights
     dev: true
 
-  /@algolia/autocomplete-plugin-algolia-insights@1.9.2(algoliasearch@4.17.0)(search-insights@2.8.3):
+  /@algolia/autocomplete-plugin-algolia-insights@1.9.2(algoliasearch@4.17.0)(search-insights@2.6.0):
     resolution: {integrity: sha512-2LVsf4W66hVHQ3Ua/8k15oPlxjELCztbAkQm/hP42Sw+GLkHAdY1vaVRYziaWq64+Oljfg6FKkZHCdgXH+CGIA==}
     peerDependencies:
       search-insights: '>= 1 < 3'
     dependencies:
       '@algolia/autocomplete-shared': 1.9.2(algoliasearch@4.17.0)
-      search-insights: 2.8.3
+      search-insights: 2.6.0
     transitivePeerDependencies:
       - '@algolia/client-search'
       - algoliasearch
@@ -510,10 +506,10 @@ packages:
     resolution: {integrity: sha512-Ob5FQLubplcBNihAVtriR59FRBeP8u69F6mu4L4yIr60KfsPc10bOV0DoPErJw0zF9IBN2cNLW9qdmt8zWPxyg==}
     dev: true
 
-  /@docsearch/js@3.5.0(search-insights@2.8.3):
+  /@docsearch/js@3.5.0(search-insights@2.6.0):
     resolution: {integrity: sha512-WqB+z+zVKSXDkGq028nClT9RvMzfFlemZuIulX5ZwWkdUtl4k7M9cmZA/c6kuZf7FG24XQsMHWuBjeUo9hLRyA==}
     dependencies:
-      '@docsearch/react': 3.5.0(search-insights@2.8.3)
+      '@docsearch/react': 3.5.0(search-insights@2.6.0)
       preact: 10.13.2
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -523,7 +519,7 @@ packages:
       - search-insights
     dev: true
 
-  /@docsearch/react@3.5.0(search-insights@2.8.3):
+  /@docsearch/react@3.5.0(search-insights@2.6.0):
     resolution: {integrity: sha512-3IG8mmSMzSHNGy2S1VuPyYU9tFCxFpj5Ov8SYwsSHM4yMvFsaO9oFxXocA5lSenliIELhuOuS5+BdxHa/Qlf2A==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 19.0.0'
@@ -537,7 +533,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@algolia/autocomplete-core': 1.9.2(algoliasearch@4.17.0)(search-insights@2.8.3)
+      '@algolia/autocomplete-core': 1.9.2(algoliasearch@4.17.0)(search-insights@2.6.0)
       '@algolia/autocomplete-preset-algolia': 1.9.2(algoliasearch@4.17.0)
       '@docsearch/css': 3.5.0
       algoliasearch: 4.17.0
@@ -2196,8 +2192,8 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+  /fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -3166,7 +3162,7 @@ packages:
       functions-have-names: 1.2.3
     dev: true
 
-  /remark-shiki-twoslash@3.1.3(typescript@5.2.2):
+  /remark-shiki-twoslash@3.1.3(typescript@5.0.4):
     resolution: {integrity: sha512-4e8OH3ySOCw5wUbDcPszokOKjKuebOqlP2WlySvC7ITBOq27BiGsFlq+FNWhxppZ+JzhTWah4gQrnMjX3KDbAQ==}
     peerDependencies:
       typescript: '>3'
@@ -3177,9 +3173,9 @@ packages:
       fenceparser: 1.1.1
       regenerator-runtime: 0.13.11
       shiki: 0.14.1
-      shiki-twoslash: 3.1.2(typescript@5.2.2)
+      shiki-twoslash: 3.1.2(typescript@5.0.4)
       tslib: 2.1.0
-      typescript: 5.2.2
+      typescript: 5.0.4
       unist-util-visit: 2.0.3
     transitivePeerDependencies:
       - supports-color
@@ -3233,7 +3229,7 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.3
+      fsevents: 2.3.2
     dev: true
 
   /rome@12.1.3:
@@ -3268,8 +3264,9 @@ packages:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: true
 
-  /search-insights@2.8.3:
-    resolution: {integrity: sha512-W9rZfQ9XEfF0O6ntgQOTI7Txc8nkZrO4eJ/pTHK0Br6wWND2sPGPoWg+yGhdIW7wMbLqk8dc23IyEtLlNGpeNw==}
+  /search-insights@2.6.0:
+    resolution: {integrity: sha512-vU2/fJ+h/Mkm/DJOe+EaM5cafJv/1rRTZpGJTuFPf/Q5LjzgMDsqPdSaZsAe+GAWHHsfsu+rQSAn6c8IGtBEVw==}
+    engines: {node: '>=8.16.0'}
     dev: true
 
   /semver@5.7.1:
@@ -3318,7 +3315,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /shiki-twoslash@3.1.2(typescript@5.2.2):
+  /shiki-twoslash@3.1.2(typescript@5.0.4):
     resolution: {integrity: sha512-JBcRIIizi+exIA/OUhYkV6jtyeZco0ykCkIRd5sgwIt1Pm4pz+maoaRZpm6SkhPwvif4fCA7xOtJOykhpIV64Q==}
     peerDependencies:
       typescript: '>3'
@@ -3327,7 +3324,7 @@ packages:
       '@typescript/vfs': 1.3.4
       fenceparser: 1.1.1
       shiki: 0.14.1
-      typescript: 5.2.2
+      typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3673,12 +3670,6 @@ packages:
     hasBin: true
     dev: true
 
-  /typescript@5.2.2:
-    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
-
   /ufo@1.1.1:
     resolution: {integrity: sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==}
     dev: true
@@ -3788,7 +3779,7 @@ packages:
       postcss: 8.4.23
       rollup: 3.21.2
     optionalDependencies:
-      fsevents: 2.3.3
+      fsevents: 2.3.2
     dev: true
 
   /vite@4.3.9(@types/node@18.16.3):
@@ -3821,27 +3812,27 @@ packages:
       postcss: 8.4.24
       rollup: 3.21.2
     optionalDependencies:
-      fsevents: 2.3.3
+      fsevents: 2.3.2
     dev: true
 
-  /vitepress-plugin-shiki-twoslash@0.0.6(typescript@5.2.2)(vitepress@1.0.0-beta.1):
+  /vitepress-plugin-shiki-twoslash@0.0.6(typescript@5.0.4)(vitepress@1.0.0-beta.1):
     resolution: {integrity: sha512-CjMF01Vb/zwOKKCqq6QmkJbTJnRxipv8oiPjRWTjzH2jPaQH4gGCF2fZHS7uY53J3gbU3GwtrXI02J6axLYmbg==}
     peerDependencies:
       vitepress: '>=1.0.0-alpha.61'
     dependencies:
-      remark-shiki-twoslash: 3.1.3(typescript@5.2.2)
-      vitepress: 1.0.0-beta.1(@types/node@18.16.3)(search-insights@2.8.3)
+      remark-shiki-twoslash: 3.1.3(typescript@5.0.4)
+      vitepress: 1.0.0-beta.1(@types/node@18.16.3)(search-insights@2.6.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /vitepress@1.0.0-beta.1(@types/node@18.16.3)(search-insights@2.8.3):
+  /vitepress@1.0.0-beta.1(@types/node@18.16.3)(search-insights@2.6.0):
     resolution: {integrity: sha512-V2yyCwQ+v9fh7rbnGDLp8M7vHa9sLElexXf/JHtBOsOwv7ed9wt1QI4WUagYgKR3TeoJT9v2s6f0UaQSne0EvQ==}
     hasBin: true
     dependencies:
       '@docsearch/css': 3.5.0
-      '@docsearch/js': 3.5.0(search-insights@2.8.3)
+      '@docsearch/js': 3.5.0(search-insights@2.6.0)
       '@vitejs/plugin-vue': 4.2.3(vite@4.3.9)(vue@3.3.4)
       '@vue/devtools-api': 6.5.0
       '@vueuse/core': 10.1.2(vue@3.3.4)

--- a/src/zod.test-d.ts
+++ b/src/zod.test-d.ts
@@ -1,47 +1,106 @@
-import type { Abi, AbiEvent } from './abi.js'
-import { Abi as AbiSchema, AbiEvent as AbiEventSchema } from './zod.js'
+import type {
+  Abi,
+  AbiConstructor,
+  AbiError,
+  AbiEvent,
+  AbiParameter,
+} from './abi.js'
+import {
+  customSolidityErrorsAbi,
+  ensRegistryWithFallbackAbi,
+  erc20Abi,
+} from './test/abis.js'
+import {
+  Abi as AbiSchema,
+  AbiConstructor as AbiConstructorSchema,
+  AbiError as AbiErrorSchema,
+  AbiEvent as AbiEventSchema,
+  AbiParameter as AbiParameterSchema,
+} from './zod.js'
 import { describe, expectTypeOf, test } from 'vitest'
 
 describe('Zod Types', () => {
-  test('assignable to Abi', () => {
-    const parsed: Abi = AbiSchema.parse([])
-    type Result = typeof parsed extends Abi ? true : false
-    expectTypeOf<Result>().toEqualTypeOf<true>()
-  })
-
-  test('extends Abi', () => {
-    const parsed = AbiSchema.parse([])
-    type Result = typeof parsed extends Abi ? true : false
-    expectTypeOf<Result>().toEqualTypeOf<true>()
-  })
-
-  test('assignable to AbiEvent', () => {
-    const parsed: AbiEvent = AbiEventSchema.parse({
-      anonymous: false,
-      inputs: [
-        { indexed: true, name: 'owner', type: 'address' },
-        { indexed: true, name: 'spender', type: 'address' },
-        { indexed: false, name: 'value', type: 'uint256' },
-      ],
-      name: 'Approval',
-      type: 'event',
+  describe('Abi', () => {
+    test('assignable to Abi', () => {
+      const parsed: Abi = AbiSchema.parse(erc20Abi)
+      type Result = typeof parsed extends Abi ? true : false
+      expectTypeOf<Result>().toEqualTypeOf<true>()
     })
-    type Result = typeof parsed extends AbiEvent ? true : false
-    expectTypeOf<Result>().toEqualTypeOf<true>()
+
+    test('extends Abi', () => {
+      const parsed = AbiSchema.parse(erc20Abi)
+      type Result = typeof parsed extends Abi ? true : false
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
   })
 
-  test('extends Abi', () => {
-    const parsed = AbiEventSchema.parse({
-      anonymous: false,
-      inputs: [
-        { indexed: true, name: 'owner', type: 'address' },
-        { indexed: true, name: 'spender', type: 'address' },
-        { indexed: false, name: 'value', type: 'uint256' },
-      ],
-      name: 'Approval',
-      type: 'event',
+  describe('AbiConstructor', () => {
+    const ensRegistryConstructor = ensRegistryWithFallbackAbi[0]
+
+    test('assignable to AbiConstructor', () => {
+      const parsed: AbiConstructor = AbiConstructorSchema.parse(
+        ensRegistryConstructor,
+      )
+      type Result = typeof parsed extends AbiConstructor ? true : false
+      expectTypeOf<Result>().toEqualTypeOf<true>()
     })
-    type Result = typeof parsed extends AbiEvent ? true : false
-    expectTypeOf<Result>().toEqualTypeOf<true>()
+
+    test('extends AbiConstructor', () => {
+      const parsed = AbiConstructorSchema.parse(ensRegistryConstructor)
+      type Result = typeof parsed extends AbiConstructor ? true : false
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+  })
+
+  describe('AbiError', () => {
+    const approvalCallerNotOwnerNorApproved = customSolidityErrorsAbi[1]
+
+    test('assignable to AbiError', () => {
+      const parsed: AbiError = AbiErrorSchema.parse(
+        approvalCallerNotOwnerNorApproved,
+      )
+      type Result = typeof parsed extends AbiError ? true : false
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+
+    test('extends AbiError', () => {
+      const parsed = AbiErrorSchema.parse(approvalCallerNotOwnerNorApproved)
+      type Result = typeof parsed extends AbiError ? true : false
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+  })
+
+  describe('AbiEvent', () => {
+    const approvalEvent = erc20Abi[0]
+
+    test('assignable to AbiEvent', () => {
+      const parsed: AbiEvent = AbiEventSchema.parse(approvalEvent)
+      type Result = typeof parsed extends AbiEvent ? true : false
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+
+    test('extends AbiEvent', () => {
+      const parsed = AbiEventSchema.parse(approvalEvent)
+      type Result = typeof parsed extends AbiEvent ? true : false
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+  })
+
+  describe('AbiParameter', () => {
+    const approvalOwnerParameter = erc20Abi[0].inputs[0]
+
+    test('assignable to AbiParameter', () => {
+      const parsed: AbiParameter = AbiParameterSchema.parse(
+        approvalOwnerParameter,
+      )
+      type Result = typeof parsed extends AbiParameter ? true : false
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+
+    test('extends AbiParameter', () => {
+      const parsed = AbiParameterSchema.parse(approvalOwnerParameter)
+      type Result = typeof parsed extends AbiParameter ? true : false
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
   })
 })

--- a/src/zod.test-d.ts
+++ b/src/zod.test-d.ts
@@ -1,5 +1,5 @@
-import type { Abi } from './abi.js'
-import { Abi as AbiSchema } from './zod.js'
+import type { Abi, AbiEvent } from './abi.js'
+import { Abi as AbiSchema, AbiEvent as AbiEventSchema } from './zod.js'
 import { describe, expectTypeOf, test } from 'vitest'
 
 describe('Zod Types', () => {
@@ -12,6 +12,36 @@ describe('Zod Types', () => {
   test('extends Abi', () => {
     const parsed = AbiSchema.parse([])
     type Result = typeof parsed extends Abi ? true : false
+    expectTypeOf<Result>().toEqualTypeOf<true>()
+  })
+
+  test('assignable to AbiEvent', () => {
+    const parsed: AbiEvent = AbiEventSchema.parse({
+      anonymous: false,
+      inputs: [
+        { indexed: true, name: 'owner', type: 'address' },
+        { indexed: true, name: 'spender', type: 'address' },
+        { indexed: false, name: 'value', type: 'uint256' },
+      ],
+      name: 'Approval',
+      type: 'event',
+    })
+    type Result = typeof parsed extends AbiEvent ? true : false
+    expectTypeOf<Result>().toEqualTypeOf<true>()
+  })
+
+  test('extends Abi', () => {
+    const parsed = AbiEventSchema.parse({
+      anonymous: false,
+      inputs: [
+        { indexed: true, name: 'owner', type: 'address' },
+        { indexed: true, name: 'spender', type: 'address' },
+        { indexed: false, name: 'value', type: 'uint256' },
+      ],
+      name: 'Approval',
+      type: 'event',
+    })
+    type Result = typeof parsed extends AbiEvent ? true : false
     expectTypeOf<Result>().toEqualTypeOf<true>()
   })
 })

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -182,7 +182,7 @@ export const AbiReceive = z.object({
 export const AbiEvent = z.object({
   type: z.literal('event'),
   anonymous: z.boolean().optional(),
-  inputs: z.array(AbiEventParameter),
+  inputs: z.array(AbiEventParameter).readonly(),
   name: Identifier,
 })
 

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -71,7 +71,7 @@ export const AbiParameter: z.ZodType<AbiParameterType> = z.lazy(() =>
       }),
       z.object({
         type: z.union([SolidityTuple, SolidityArrayWithTuple]),
-        components: z.array(AbiParameter),
+        components: z.array(AbiParameter).readonly(),
       }),
     ]),
   ),
@@ -110,9 +110,9 @@ export const AbiFunction = z.preprocess(
      * https://github.com/vyperlang/vyper/issues/2151
      */
     gas: z.number().optional(),
-    inputs: z.array(AbiParameter),
+    inputs: z.array(AbiParameter).readonly(),
     name: Identifier,
-    outputs: z.array(AbiParameter),
+    outputs: z.array(AbiParameter).readonly(),
     /**
      * @deprecated use `payable` or `nonpayable` from {@link AbiStateMutability} instead
      * https://github.com/ethereum/solidity/issues/992
@@ -138,7 +138,7 @@ export const AbiConstructor = z.preprocess(
      * @deprecated use `pure` or `view` from {@link AbiStateMutability} instead
      * https://github.com/ethereum/solidity/issues/992
      */
-    inputs: z.array(AbiParameter),
+    inputs: z.array(AbiParameter).readonly(),
     /**
      * @deprecated use `payable` or `nonpayable` from {@link AbiStateMutability} instead
      * https://github.com/ethereum/solidity/issues/992
@@ -188,7 +188,7 @@ export const AbiEvent = z.object({
 
 export const AbiError = z.object({
   type: z.literal('error'),
-  inputs: z.array(AbiParameter),
+  inputs: z.array(AbiParameter).readonly(),
   name: z.string(),
 })
 
@@ -263,14 +263,14 @@ export const Abi = z.array(
         z.discriminatedUnion('type', [
           z.object({
             type: z.literal('function'),
-            inputs: z.array(AbiParameter),
+            inputs: z.array(AbiParameter).readonly(),
             name: z.string().regex(/[a-zA-Z$_][a-zA-Z0-9$_]*/),
-            outputs: z.array(AbiParameter),
+            outputs: z.array(AbiParameter).readonly(),
             stateMutability: AbiStateMutability,
           }),
           z.object({
             type: z.literal('constructor'),
-            inputs: z.array(AbiParameter),
+            inputs: z.array(AbiParameter).readonly(),
             stateMutability: z.union([
               z.literal('payable'),
               z.literal('nonpayable'),


### PR DESCRIPTION
## Description

This PR upgrades [`zod` to v3.22+ to get access to `ZodReadonly`](https://github.com/colinhacks/zod/releases/tag/v3.22.0).
This allow to update the `zod` schemas from `abitype/zod` so  type from `abitype`.

Added readonly to the following types:

- `AbiContructor.inputs`
- `AbiError.inputs`
- `AbiEvent.inputs`
- `AbiFunction.inputs` / `AbiFunction.outputs`

## Additional Information

- [X] I read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [X] I added documentation related to the changes made.
- [X] I added or updated tests related to the changes made.

Your ENS/address: `windyy.eth`

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Changed the following types to readonly in zod package: `AbiContructor.inputs`, `AbiError.inputs`, `AbiEvent.inputs`, `AbiFunction.inputs` / `AbiFunction.outputs`
- Updated the `zod` package version to `3.22.4` in `pnpm-lock.yaml`
- Updated the `zod` package version to `^3 >=3.22.0` in `package.json`
- Added a note in `CONTRIBUTING.md` to use `pnpm@8.3.1` and `typescript@5.0.4` for installing or upgrading packages
- Added a note in `CONTRIBUTING.md` to build the package before running the `test:typecheck` suite
- Updated the `zod.ts` file to make the `components`, `inputs`, and `outputs` properties readonly in various types
- Updated the `zod.test-d.ts` file to import additional types and test their assignability and extension

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->