### PR TITLE
fix: parse Abi with zod as readonly array

### DIFF
--- a/.changeset/hungry-pets-switch.md
+++ b/.changeset/hungry-pets-switch.md
@@ -2,4 +2,4 @@
 "abitype": patch
 ---
 
-parse `Abi` with `zod` as `readonly` array
+Marked `Abi` Zod schema as `readonly`.

--- a/.changeset/hungry-pets-switch.md
+++ b/.changeset/hungry-pets-switch.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+parse `Abi` with `zod` as `readonly` array


### PR DESCRIPTION
## Description

Supersedes #197

This PR sets the `zod` `Abi` schema from `abitype/zod` as `readonly []` to match the `Abi` type declared in `abitype`.


## Additional Information

Before submitting this issue, please make sure you do the following.

- [X] Read the [contributing guide](https://github.com/wagmi-dev/abitype/blob/main/.github/CONTRIBUTING.md)
- [X] Added documentation related to the changes made.
- [X] Added or updated tests (and snapshots) related to the changes made.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
The focus of this PR is to mark the `Abi` Zod schema as `readonly`.

### Detailed summary:
- Marked `Abi` Zod schema as `readonly`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->