### PR TITLE
fix: move type field to dist/esm/package.json

### DIFF
--- a/.changeset/smart-students-talk.md
+++ b/.changeset/smart-students-talk.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+Fixed error with TypeScript 5.2.2 in CommonJS projects.

--- a/.changeset/smart-students-talk.md
+++ b/.changeset/smart-students-talk.md
@@ -2,4 +2,4 @@
 "abitype": patch
 ---
 
-Fixed error with TypeScript 5.2.2 in CommonJS projects.
+Fixes an error with TypeScript 5.2.2 in CommonJS projects..

--- a/.scripts/formatPackageJson.ts
+++ b/.scripts/formatPackageJson.ts
@@ -30,7 +30,7 @@ for (const packagePath of packagePaths) {
     `${JSON.stringify(packageJson, undefined, 2)}\n`,
   )
 
-  const { devDependencies: _dD, scripts: _s, ...rest } = packageJson
+  const { devDependencies: _dD, scripts: _s, type: _t, ...rest } = packageJson
   await Bun.write(packagePath, `${JSON.stringify(rest, undefined, 2)}\n`)
 }
 

--- a/packages/abitype/package.json
+++ b/packages/abitype/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm+types",
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --moduleResolution node10 --outDir ./dist/cjs --removeComments --verbatimModuleSyntax false && echo > ./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm+types": "tsc --project tsconfig.build.json --module es2020 --outDir ./dist/esm --declaration --declarationMap --declarationDir ./dist/types",
+    "build:esm+types": "tsc --project tsconfig.build.json --module es2020 --outDir ./dist/esm --declaration --declarationMap --declarationDir ./dist/types && echo > ./dist/esm/package.json '{\"type\":\"module\",\"sideEffects\":false}'",
     "clean": "rm -rf dist tsconfig.tsbuildinfo abis zod",
     "test:build": "publint --strict",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
Fixes #204 as suggested in https://github.com/wagmi-dev/abitype/issues/204#issuecomment-1783939226.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an error with TypeScript 5.2.2 in CommonJS projects.

### Detailed summary
- Added `"type": "module"` to the `build:esm+types` script in `packages/abitype/package.json`
- Added `"sideEffects": false` to the `build:esm+types` script in `packages/abitype/package.json`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->