### PR TITLE
chore: fix typo

### DIFF
--- a/docs/pages/api/types.md
+++ b/docs/pages/api/types.md
@@ -72,7 +72,7 @@ import { AbiInternalType } from 'abitype'
 
 ## `AbiParameter`
 
-`inputs` and `ouputs` item for ABI functions, errors, and constructors
+`inputs` and `outputs` item for ABI functions, errors, and constructors
 
 ```ts twoslash noplayground
 import { AbiParameter } from 'abitype'


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/abitype/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to ABIType!
----------------------------------------------------------------------->

Fix typo within doc


<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes a typo in the `AbiParameter` interface by correcting `ouputs` to `outputs`.

### Detailed summary
- Fixed a typo in the `AbiParameter` interface: `ouputs` changed to `outputs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->