### PR TITLE
fix: identifier should be alnum

### DIFF
--- a/.changeset/fix-identifier-regex.md
+++ b/.changeset/fix-identifier-regex.md
@@ -1,0 +1,5 @@
+---
+"abitype": patch
+---
+
+Fixed Zod identifier regex to anchor start and end, rejecting invalid identifiers like `café`, `2g`, and `hello👋`.

--- a/packages/abitype/src/zod.test.ts
+++ b/packages/abitype/src/zod.test.ts
@@ -761,7 +761,21 @@ test('EIP-712 TypedData', () => {
         "path": []
       }
     ]]
-  `)
+  `);
+
+  expect(() => TypedData.parse({ café: [{ name: "owner", type: "address" }] }))
+    .toThrowErrorMatchingInlineSnapshot(`
+    [ZodError: [
+      {
+        "validation": "regex",
+        "code": "invalid_string",
+        "message": "Invalid",
+        "path": [
+          "café"
+        ]
+      }
+    ]]
+  `);
 
   const single = {
     Contributor: [

--- a/packages/abitype/src/zod.test.ts
+++ b/packages/abitype/src/zod.test.ts
@@ -761,10 +761,11 @@ test('EIP-712 TypedData', () => {
         "path": []
       }
     ]]
-  `);
+  `)
 
-  expect(() => TypedData.parse({ café: [{ name: "owner", type: "address" }] }))
-    .toThrowErrorMatchingInlineSnapshot(`
+  expect(() =>
+    TypedData.parse({ café: [{ name: 'owner', type: 'address' }] }),
+  ).toThrowErrorMatchingInlineSnapshot(`
     [ZodError: [
       {
         "validation": "regex",
@@ -775,7 +776,52 @@ test('EIP-712 TypedData', () => {
         ]
       }
     ]]
-  `);
+  `)
+
+  expect(() =>
+    TypedData.parse({ '2g': [{ name: 'owner', type: 'address' }] }),
+  ).toThrowErrorMatchingInlineSnapshot(`
+    [ZodError: [
+      {
+        "validation": "regex",
+        "code": "invalid_string",
+        "message": "Invalid",
+        "path": [
+          "2g"
+        ]
+      }
+    ]]
+  `)
+
+  expect(() =>
+    TypedData.parse({ 'hello👋': [{ name: 'owner', type: 'address' }] }),
+  ).toThrowErrorMatchingInlineSnapshot(`
+    [ZodError: [
+      {
+        "validation": "regex",
+        "code": "invalid_string",
+        "message": "Invalid",
+        "path": [
+          "hello👋"
+        ]
+      }
+    ]]
+  `)
+
+  expect(() =>
+    TypedData.parse({ 'good 運': [{ name: 'owner', type: 'address' }] }),
+  ).toThrowErrorMatchingInlineSnapshot(`
+    [ZodError: [
+      {
+        "validation": "regex",
+        "code": "invalid_string",
+        "message": "Invalid",
+        "path": [
+          "good 運"
+        ]
+      }
+    ]]
+  `)
 
   const single = {
     Contributor: [

--- a/packages/abitype/src/zod.ts
+++ b/packages/abitype/src/zod.ts
@@ -14,7 +14,7 @@ import type {
 import { isSolidityType } from './human-readable/runtime/utils.js'
 import { bytesRegex, execTyped, integerRegex } from './regex.js'
 
-const Identifier = z.string().regex(/[a-zA-Z$_][a-zA-Z0-9$_]*/)
+const Identifier = z.string().regex(/^[a-zA-Z$_][a-zA-Z0-9$_]*$/);
 
 export const Address = z.string().transform((val, ctx) => {
   const regex = /^0x[a-fA-F0-9]{40}$/

--- a/packages/abitype/src/zod.ts
+++ b/packages/abitype/src/zod.ts
@@ -14,7 +14,7 @@ import type {
 import { isSolidityType } from './human-readable/runtime/utils.js'
 import { bytesRegex, execTyped, integerRegex } from './regex.js'
 
-const Identifier = z.string().regex(/^[a-zA-Z$_][a-zA-Z0-9$_]*$/);
+const Identifier = z.string().regex(/^[a-zA-Z$_][a-zA-Z0-9$_]*$/)
 
 export const Address = z.string().transform((val, ctx) => {
   const regex = /^0x[a-fA-F0-9]{40}$/


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

regex seems too lax, it matches as long as it contains a letter`z.string().regex(/[a-zA-Z$_][a-zA-Z0-9$_]*/),`

let's try out:
```ts
const identifier = z.string().regex(/[a-zA-Z$_][a-zA-Z0-9$_]*/)
identifier.parse("é") // throws ✅
identifier.parse("2") // throws ✅
identifier.parse("👋") // throws ✅
identifier.parse("運") // throws ✅
```

unfortunately, it does not catch these invalid identifiers names

```ts
identifier.parse("2g") // passes ❌
identifier.parse("café") // passes ❌
identifier.parse("été") // passes ❌
identifier.parse("hello👋") // passes ❌
identifer.parse("good 運") // passes ❌
```

you can try by yourself on https://zod-playground.vercel.app/


I added tests in the TypedData, but I wonder if I should test this individually. It would require to `export const Identifier`


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/abitype/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to ABIType!
----------------------------------------------------------------------->
