### PR TITLE
Fix import for AbiItemType in types documentation

### DIFF
--- a/docs/pages/api/types.md
+++ b/docs/pages/api/types.md
@@ -67,7 +67,7 @@ import { AbiInternalType } from 'abitype'
 `"type"` name for [`Abi`](#abi) items (e.g. `'type': 'function'` for [`AbiFunction`](#abifunction))
 
 ```ts twoslash noplayground
-import { AbiInternalType } from 'abitype'
+import { AbiItemType } from 'abitype'
 ```
 
 ## `AbiParameter`


### PR DESCRIPTION
This pull request updates the documentation in `docs/pages/api/types.md` to reflect a change in the import statement for a type from the `abitype` package.

Documentation update:

* Changed the import statement from `AbiInternalType` to `AbiItemType` in the code example to match the current API of the `abitype` package.