### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/docs/pages/guide/getting-started.md
+++ b/docs/pages/guide/getting-started.md
@@ -17,6 +17,9 @@ npm i abitype
 ```bash [yarn]
 yarn add abitype
 ```
+```bash [deno]
+deno add abitype
+```
 :::
 
 :::info[TypeScript Version]


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The install code-group lists the usual package managers. Since Deno is a drop-in replacement for npm these days, this adds a Deno entry in parity:

```sh
deno add abitype
```

Docs-only change. Totally fine to close this if you'd rather not. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
