### PR TITLE
docs: use current config option names

### DIFF
--- a/docs/pages/config.md
+++ b/docs/pages/config.md
@@ -74,7 +74,7 @@ import 'abitype'
 // ---cut---
 declare module 'abitype' {
   export interface Register {
-    ArrayMaxDepth: false
+    arrayMaxDepth: false
   }
 }
 ```
@@ -128,7 +128,7 @@ import 'abitype'
 // ---cut---
 declare module 'abitype' {
   export interface Register {
-    FixedArrayMinLength: 1
+    fixedArrayMinLength: 1
   }
 }
 ```
@@ -145,7 +145,7 @@ import 'abitype'
 // ---cut---
 declare module 'abitype' {
   export interface Register {
-    FixedArrayMinLength: 99
+    fixedArrayMaxLength: 99
   }
 }
 ```


### PR DESCRIPTION
## Summary

Updates the configuration docs examples to use the current `Register` option names:

- `arrayMaxDepth` instead of deprecated `ArrayMaxDepth`
- `fixedArrayMinLength` instead of deprecated `FixedArrayMinLength`
- `fixedArrayMaxLength` in the `fixedArrayMaxLength` example

This keeps the examples aligned with the option headings and avoids copying deprecated or incorrect keys from the docs.

## Validation

- `git diff --check`
- `rg "ArrayMaxDepth|FixedArrayMinLength|FixedArrayMaxLength" docs/pages/config.md -n`
- `rg "arrayMaxDepth|fixedArrayMinLength|fixedArrayMaxLength" docs/pages/config.md -n`

Docs-only change; I did not run the full docs build locally because dependencies were not installed in this checkout.
